### PR TITLE
AWR1843 always takes 12 compRangeBiasAndRxChanPhase pairs

### DIFF
--- a/src/xwr/radar/api.py
+++ b/src/xwr/radar/api.py
@@ -153,7 +153,7 @@ class AWR1642(XWRBase):
         self.frameCfg(
             numLoops=frame_length, chirpEndIdx=num_tx - 1,
             framePeriodicity=frame_period)
-        self.compRangeBiasAndRxChanPhase(rx_phase = [(0, 1)] * 4 * num_tx)
+        self.compRangeBiasAndRxChanPhase(rx_phase = [(0, 1)] * 4 * 3)
         self.send("bpmCfg -1 0 0 1")
         self.lvdsStreamCfg()
 


### PR DESCRIPTION
It appears that the AWR1843Boost firmware expects 12 compRangeBiasAndRxChanPhase I/Q pairs (i.e., for each tx-rx pair) even when only 2 transmitters are active.