### PR TITLE
Fix documentation CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ docs = [
     "mkdocs-material == 9.6.*",
     "mkdocstrings-python-xref == 1.16.3",
     "mkdocstrings-python == 1.16.6",
-    "ruff >= 0.11.0"
+    "griffe == 1.8.0",
+    "ruff >= 0.11.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -303,14 +303,14 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.14.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/d7/6c09dd7ce4c7837e4cdb11dce980cb45ae3cd87677298dc3b781b6bce7d3/griffe-1.14.0.tar.gz", hash = "sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13", size = 424684, upload-time = "2025-09-05T15:02:29.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/72/10c5799440ce6f3001b7913988b50a99d7b156da71fe19be06178d5a2dd5/griffe-1.8.0.tar.gz", hash = "sha256:0b4658443858465c13b2de07ff5e15a1032bc889cfafad738a476b8b97bb28d7", size = 401098, upload-time = "2025-07-22T23:45:54.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/b1/9ff6578d789a89812ff21e4e0f80ffae20a65d5dd84e7a17873fe3b365be/griffe-1.14.0-py3-none-any.whl", hash = "sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0", size = 144439, upload-time = "2025-09-05T15:02:27.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/a839fcc28bebfa72925d9121c4d39398f77f95bcba0cf26c972a0cfb1de7/griffe-1.8.0-py3-none-any.whl", hash = "sha256:110faa744b2c5c84dd432f4fa9aa3b14805dd9519777dd55e8db214320593b02", size = 132487, upload-time = "2025-07-22T23:45:52.778Z" },
 ]
 
 [[package]]
@@ -1938,6 +1938,7 @@ dev = [
 ]
 docs = [
     { name = "abstract-dataloader" },
+    { name = "griffe" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings-python" },
@@ -1960,6 +1961,7 @@ requires-dist = [
     { name = "abstract-dataloader", marker = "extra == 'docs'", specifier = ">=0.3.5" },
     { name = "beartype", specifier = ">=0.20" },
     { name = "coverage", marker = "extra == 'dev'" },
+    { name = "griffe", marker = "extra == 'docs'", specifier = "==1.8.0" },
     { name = "jax", marker = "extra == 'jax'", specifier = ">=0.4.0" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.*" },


### PR DESCRIPTION
Turns out `griffe 1.9.0` added some Type Parameter parsing features which broke downstream compatibility, so we need to pin `1.8.0` until the mkdocstrings ecosystem fixes it.

This should get the Docs CI building again.