### PR TITLE
fix parameter assertion issue

### DIFF
--- a/src/xwr/system.py
+++ b/src/xwr/system.py
@@ -57,6 +57,7 @@ class XWRSystem(Generic[TRadar]):
             capture = DCAConfig(**capture)
 
         self.log: logging.Logger = logging.getLogger(name)
+        self.strict = strict
         self._check_config(radar, capture)
 
         self.dca: DCA1000EVM = capture.create()
@@ -65,7 +66,6 @@ class XWRSystem(Generic[TRadar]):
 
         self.config = radar
         self.fps: float = 1000.0 / radar.frame_period
-        self.strict = strict
 
     def _assert(self, cond: bool, desc: str) -> None:
         """Check a condition and log (or raise) a warning if it is not met."""


### PR DESCRIPTION
The parameter assertion was failing because grt-i has a duty cycle of 99.5%, which we need strict=False to relax it. But "self.strict" was defined later than used in "self._check_config()" when calling self._assert(). 