### PR TITLE
Constraint checking & documentation

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -1,17 +1,1 @@
 ::: xwr.constraints
-    options:
-        members:
-        - ConstraintCheck
-        - Constraint
-        - DutyCycle
-        - ExcessRampTime
-        - CubeSizeLimit
-        - FrameLengthPowerOfTwo
-        - AdcSamplesPowerOfTwo
-        - MaxSampleRate
-        - MinSampleRate
-        - MaxBandwidth
-        - NetworkUtilization
-        - ReceiveBuffer
-        - CONSTRAINTS
-        - check_config

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -1,0 +1,17 @@
+::: xwr.constraints
+    options:
+        members:
+        - ConstraintCheck
+        - Constraint
+        - DutyCycle
+        - ExcessRampTime
+        - CubeSizeLimit
+        - FrameLengthPowerOfTwo
+        - AdcSamplesPowerOfTwo
+        - MaxSampleRate
+        - MinSampleRate
+        - MaxBandwidth
+        - NetworkUtilization
+        - ReceiveBuffer
+        - CONSTRAINTS
+        - check_config

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,14 +12,14 @@
 [![CI](https://github.com/RadarML/xwr/actions/workflows/ci.yml/badge.svg)](https://github.com/RadarML/xwr/actions/workflows/ci.yml)
 ![GitHub issues](https://img.shields.io/github/issues/RadarML/xwr)
 
-`xwr` is a pure-python, linux-based real time raw data capture system for TI mmWave radars, and includes four key components:
+`xwr` is a python-based real time raw data capture system for TI mmWave radars, and includes four key components:
 
 <div class="grid cards" markdown>
 
 - [`xwr`](system.md): a high-level data capture interface
 - [`xwr.rsp`](rsp/index.md): a radar signal processing library with [Numpy](rsp/numpy.md), [Pytorch](rsp/torch.md), and [Jax](rsp/jax.md) support
 - [`xwr.radar`](radar/api.md): a parameterized python interface for the default radar firmware
-- [`xwr.capture`](dca/api.md): a pure-python, real-time interface for the DCA1000EVM
+- [`xwr.capture`](dca/api.md): a real-time interface for the DCA1000EVM
 
 </div>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,7 +67,7 @@ sudo chmod 777 /dev/ttyACM0  # or whatever port the radar is on.
 
 The high level interface for `xwr` includes a capture card configuration ([`DCAConfig`][xwr.DCAConfig]) and a radar configuration ([`XWRConfig`][xwr.XWRConfig]).
 
-While the capture card configuration can be [left as default][xwr.DCAConfig], the radar requires a valid modulation to be configured; see [`XWRConfig`][xwr.XWRConfig] for details.
+While the capture card configuration can be [left as default][xwr.DCAConfig], the radar requires a valid modulation to be configured; see [`XWRConfig`][xwr.XWRConfig] and the [known constraints](./constraints.md) for details.
 
 !!! tip
 
@@ -75,7 +75,7 @@ While the capture card configuration can be [left as default][xwr.DCAConfig], th
 
 As a general guideline:
 
-1. Select a range/doppler resolution in bins; there appears to be an effective limitation on the total range-Doppler frame size of `2^14` (i.e., `128x128`, `64x256`, etc is the maximum size).
+1. Select a range/doppler resolution in bins.
     - The number of range bins is the `adc_samples`.
     - The number of doppler bins is the `frame_length`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
       - Hardware Setup: setup.md
       - Development: develop.md
     - High Level API: system.md
+    - Constraints: constraints.md
     - ROS Node: ros.md
     - Firmware: firmware.md
   - Radar Processing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ allow-direct-references = true
 
 [project]
 name = "xwr"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
   { name="Tianshu Huang", email="tianshu2@andrew.cmu.edu" },
 ]
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
     "Operating System :: POSIX :: Linux",
 ]

--- a/src/xwr/__init__.py
+++ b/src/xwr/__init__.py
@@ -15,7 +15,11 @@ beartype_this_package()
 # ruff: noqa: E402
 from . import capture, radar, rsp
 from .config import DCAConfig, XWRConfig
+from .constraints import Constraint, ConstraintCheck, check_config
 from .system import XWRSystem
 
 __all__ = [
-    "capture", "radar", "rsp", "XWRConfig", "XWRSystem", "DCAConfig"]
+    "capture", "radar", "rsp",
+    "XWRConfig", "XWRSystem", "DCAConfig",
+    "Constraint", "ConstraintCheck", "check_config",
+]

--- a/src/xwr/capture/api.py
+++ b/src/xwr/capture/api.py
@@ -86,7 +86,7 @@ class DCA1000EVM:
         data_port: int = 4098, config_port: int = 4096, timeout: float = 1.0,
         socket_buffer: int = 2048000, name: str = "DCA1000EVM"
     ) -> None:
-        self.log: logging.Logger = logging.getLogger(name=name)
+        self.log: logging.Logger = logging.getLogger(name=f"xwr/{name}")
 
         self.sys_ip = sys_ip
         self.fpga_ip = fpga_ip

--- a/src/xwr/config.py
+++ b/src/xwr/config.py
@@ -16,6 +16,11 @@ class XWRConfig:
     https://dev.ti.com/gallery/view/mmwave/mmWaveSensingEstimator/ver/2.4.0/)
     may be helpful for creating a configuration.
 
+    !!! info
+
+        Attributes marked with *(derived)* are computed from other attributes,
+        i.e., are `@property` attributes.
+
     Attributes:
         device: radar device type, or the name of a radar device class in
             [`xwr.radar`][xwr.radar].
@@ -32,6 +37,23 @@ class XWRConfig:
         frame_period: periodicity of frames, in ms.
         port: Control serial port (usually `/dev/ttyACM0`). Use `None` to
             auto-detect; see [`XWRBase`][xwr.radar.XWRBase].
+        device_name: *(derived)* Device class name; used as constraint lookup key.
+        device_type: *(derived)* Radar device type.
+        num_tx: *(derived)* Number of TX antennas.
+        num_rx: *(derived)* Number of RX antennas.
+        shape: *(derived)* Radar data cube shape.
+        raw_shape: *(derived)* Radar IIQQ data shape.
+        frame_size: *(derived)* Radar data cube size, in bytes.
+        chirp_time: *(derived)* Per-TX antenna inter-chirp time T_c, in microseconds.
+        frame_time: *(derived)* Total radar frame time, in ms.
+        sample_time: *(derived)* Total sampling time T_s, in us.
+        bandwidth: *(derived)* Effective bandwidth, in MHz.
+        range_resolution: *(derived)* Range resolution, in m.
+        max_range: *(derived)* Maximum range, in m.
+        wavelength: *(derived)* Center wavelength, in m.
+        doppler_resolution: *(derived)* Doppler resolution, in m/s.
+        max_doppler: *(derived)* Maximum doppler velocity, in m/s.
+        throughput: *(derived)* Average throughput, in bits/sec.
     """
 
     device: type[radar.XWRBase] | str
@@ -48,8 +70,11 @@ class XWRConfig:
     port: str | None = None
 
     @property
+    def device_name(self) -> str:
+        return self.device_type.__name__
+
+    @property
     def device_type(self) -> type[radar.XWRBase]:
-        """Radar device type."""
         if isinstance(self.device, str):
             try:
                 return getattr(radar, self.device)
@@ -60,84 +85,69 @@ class XWRConfig:
 
     @property
     def num_tx(self) -> int:
-        """Number of TX antennas."""
         return self.device_type.NUM_TX
 
     @property
     def num_rx(self) -> int:
-        """Number of RX antennas."""
         return self.device_type.NUM_RX
 
     @property
     def shape(self) -> tuple[int, int, int, int]:
-        """Radar data cube shape."""
         return (
             self.frame_length, self.num_tx, self.num_rx, self.adc_samples)
 
     @property
     def raw_shape(self) -> tuple[int, int, int, int]:
-        """Radar IIQQ data shape."""
         return (
             self.frame_length, self.num_tx, self.num_rx, self.adc_samples
             * self.device_type.BYTES_PER_SAMPLE // 2)
 
     @property
     def frame_size(self) -> int:
-        """Radar data cube size, in bytes."""
         return (self.frame_length * self.num_tx * self.num_rx *
                 self.adc_samples * self.device_type.BYTES_PER_SAMPLE)
 
     @property
     def chirp_time(self) -> float:
-        """Per-TX antenna inter-chirp time T_c, in microseconds."""
         return (self.idle_time + self.ramp_end_time) * self.num_tx
 
     @property
     def frame_time(self) -> float:
-        """Total radar frame time, in ms."""
         return self.chirp_time * self.frame_length / 1e3
 
     @property
     def sample_time(self) -> float:
-        """Total sampling time T_s, in us."""
         return self.adc_samples / self.sample_rate * 1e3
 
     @property
     def bandwidth(self) -> float:
-        """Effective bandwidth, in MHz."""
         return self.freq_slope * self.sample_time
 
     @property
     def range_resolution(self) -> float:
-        """Range resolution, in m."""
         return SPEED_OF_LIGHT / (2 * self.bandwidth * 1e6)
 
     @property
     def max_range(self) -> float:
-        """Maximum range, in m."""
         return self.range_resolution * self.adc_samples
 
     @property
     def wavelength(self) -> float:
-        """Center wavelength, in m."""
         offset_time = self.adc_start_time + self.sample_time / 2
         return SPEED_OF_LIGHT / (
             self.frequency * 1e9 + self.freq_slope * (offset_time) * 1e6)
 
     @property
     def doppler_resolution(self) -> float:
-        """Doppler resolution, in m/s."""
         return (
             self.wavelength / (2 * self.frame_length * self.chirp_time * 1e-6))
 
     @property
     def max_doppler(self) -> float:
-        """Maximum doppler velocity, in m/s."""
         return self.wavelength / (4 * self.chirp_time * 1e-6)
 
     @property
     def throughput(self) -> float:
-        """Average throughput, in bits/sec."""
         return self.frame_size * 8 / self.frame_period * 1e3
 
     def as_dict(self) -> dict[str, float | int]:

--- a/src/xwr/constraints.py
+++ b/src/xwr/constraints.py
@@ -1,0 +1,343 @@
+"""Radar configuration constraints.
+
+This module documents and enforces known constraints on radar configurations.
+
+!!! warning
+
+    These constraints are not exhaustive or guaranteed to be correct. If you
+    find a missing constraint, or run into an undocumented or incorrectly
+    implemented check, please open an issue!
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import ClassVar
+
+from .config import DCAConfig, XWRConfig
+
+
+class Constraint(ABC):
+    """Base class for a radar configuration constraint."""
+
+    @staticmethod
+    @abstractmethod
+    def check(
+        radar: XWRConfig, capture: DCAConfig | None = None
+    ) -> "ConstraintCheck":
+        """Return a [`ConstraintCheck`][xwr.constraints.ConstraintCheck] result."""
+
+
+@dataclass(frozen=True)
+class ConstraintCheck:
+    """Result of a single constraint check.
+
+    Attributes:
+        constraint: type of the constraint being checked.
+        passed: `True` if the constraint is satisfied, `False` if violated, or
+            `None` if not applicable.
+        detail: computed value (on pass/skip) or violation description
+            (on fail).
+    """
+
+    constraint: type[Constraint]
+    passed: bool | None
+    detail: str
+
+
+class DutyCycle(Constraint):
+    """Active frame time must not exceed the frame period.
+
+    The fraction of each period spent actively transmitting must stay
+    below 99%:
+
+        frame_time / frame_period < 99%
+
+    where `frame_time = chirp_time × frame_length / 1000` ms (see
+    [`XWRConfig.frame_time`][xwr.config.XWRConfig]).
+    """
+
+    @staticmethod
+    def check(radar, capture=None):
+        duty_cycle = 100 * radar.frame_time / radar.frame_period
+        passed = duty_cycle < 99
+        detail = f"duty cycle = {duty_cycle:.1f}%"
+        if not passed:
+            detail += " (must be < 99%)"
+        return ConstraintCheck(DutyCycle, passed, detail)
+
+
+class ExcessRampTime(Constraint):
+    """ADC sampling must complete before the frequency ramp ends.
+
+    The ADC window must fit within the chirp ramp:
+
+        ramp_end_time - adc_start_time ≥ T_s
+
+    where `T_s = adc_samples / sample_rate × 1000` μs (see
+    [`XWRConfig.sample_time`][xwr.config.XWRConfig]).
+    """
+
+    @staticmethod
+    def check(radar, capture=None):
+        excess = radar.ramp_end_time - radar.adc_start_time - radar.sample_time
+        passed = excess >= 0
+        detail = f"excess ramp time = {excess:.1f}us"
+        if not passed:
+            detail += " (must be ≥ 0)"
+        return ConstraintCheck(ExcessRampTime, passed, detail)
+
+
+class CubeSizeLimit(Constraint):
+    """Radar data cube must fit within the device L3 radar buffer.
+
+    Checks `frame_size` (total bytes for one frame) against the device
+    hardware L3 memory limit:
+
+        frame_size ≤ _LIMITS[device_name]
+
+    where `frame_size = frame_length × num_tx × num_rx × adc_samples
+    × BYTES_PER_SAMPLE` (see [`XWRConfig.frame_size`][xwr.config.XWRConfig]).
+
+    | Device   | L3 size  |
+    |----------|----------|
+    | AWR1642  | 768 KiB  |
+    | AWR1843  | 1 MiB    |
+    | AWR2944  | 2.5 MiB  |
+    | AWRL6844 | 896 KiB  |
+    """
+
+    _LIMITS: ClassVar[dict[str, int]] = {
+        "AWR1642":  768 * 1024,
+        "AWR1843":  1024 * 1024,
+        "AWR1843L": 1024 * 1024,
+        "AWR2944":  int(2.5 * 1024 * 1024),
+        "AWRL6844": 896 * 1024,
+    }
+
+    @staticmethod
+    def check(radar, capture=None):
+        limit = CubeSizeLimit._LIMITS.get(radar.device_name)
+        if limit is None:
+            return ConstraintCheck(
+                CubeSizeLimit, None,
+                f"not checked for {radar.device_name}")
+        passed = radar.frame_size <= limit
+        detail = (
+            f"frame_size = {radar.frame_size} bytes, "
+            f"L3 limit = {limit} bytes ({limit // 1024} KiB)")
+        if not passed:
+            detail = (
+                f"frame_size = {radar.frame_size} bytes "
+                f"> device L3 limit {limit} bytes ({limit // 1024} KiB)")
+        return ConstraintCheck(CubeSizeLimit, passed, detail)
+
+
+class FrameLengthPowerOfTwo(Constraint):
+    """Frame length must be a power of two.
+
+    The number of chirps per TX antenna per frame must be a power of two
+    for the range-Doppler FFT:
+
+        frame_length & (frame_length - 1) == 0
+    """
+
+    @staticmethod
+    def check(radar, capture=None):
+        fl = radar.frame_length
+        passed = fl & (fl - 1) == 0
+        detail = f"frame_length = {fl}"
+        if not passed:
+            detail += " (not a power of two)"
+        return ConstraintCheck(FrameLengthPowerOfTwo, passed, detail)
+
+
+class AdcSamplesPowerOfTwo(Constraint):
+    """ADC samples per chirp must be a power of two.
+
+    The number of samples per chirp must be a power of two for the
+    range FFT:
+
+        adc_samples & (adc_samples - 1) == 0
+    """
+
+    @staticmethod
+    def check(radar, capture=None):
+        n = radar.adc_samples
+        passed = n & (n - 1) == 0
+        detail = f"adc_samples = {n}"
+        if not passed:
+            detail += " (not a power of two)"
+        return ConstraintCheck(AdcSamplesPowerOfTwo, passed, detail)
+
+
+class MaxSampleRate(Constraint):
+    """ADC sampling rate must not exceed the device maximum.
+
+    | Device   | Maximum     |
+    |----------|-------------|
+    | AWR1642  | 12,500 Ksps |
+    | AWR1843  | 25,000 Ksps |
+    | AWR2944  | 37,500 Ksps |
+    | AWRL6844 | 25,000 Ksps |
+    """
+
+    _LIMITS: ClassVar[dict[str, int]] = {
+        "AWR1642":  12_500,
+        "AWR1843":  25_000,
+        "AWR1843L": 25_000,
+        "AWR2944":  37_500,
+        "AWRL6844": 25_000,
+    }
+
+    @staticmethod
+    def check(radar, capture=None):
+        limit = MaxSampleRate._LIMITS.get(radar.device_name)
+        if limit is None:
+            return ConstraintCheck(
+                MaxSampleRate, None,
+                f"not checked for {radar.device_name}")
+        passed = radar.sample_rate <= limit
+        detail = f"sample_rate = {radar.sample_rate} Ksps, maximum = {limit} Ksps"
+        if not passed:
+            detail = (
+                f"sample_rate = {radar.sample_rate} Ksps "
+                f"> device maximum {limit} Ksps")
+        return ConstraintCheck(MaxSampleRate, passed, detail)
+
+
+class MinSampleRate(Constraint):
+    """ADC sampling rate must meet the device minimum.
+
+    | Device   | Minimum    |
+    |----------|------------|
+    | AWR1843  | 2,000 Ksps |
+    """
+
+    _LIMITS: ClassVar[dict[str, int]] = {
+        "AWR1843":  2_000,
+        "AWR1843L": 2_000,
+    }
+
+    @staticmethod
+    def check(radar, capture=None):
+        limit = MinSampleRate._LIMITS.get(radar.device_name)
+        if limit is None:
+            return ConstraintCheck(
+                MinSampleRate, None,
+                f"not checked for {radar.device_name}")
+        passed = radar.sample_rate >= limit
+        detail = f"sample_rate = {radar.sample_rate} Ksps, minimum = {limit} Ksps"
+        if not passed:
+            detail = (
+                f"sample_rate = {radar.sample_rate} Ksps "
+                f"< device minimum {limit} Ksps")
+        return ConstraintCheck(MinSampleRate, passed, detail)
+
+
+class MaxBandwidth(Constraint):
+    """Effective chirp bandwidth must not exceed the device RF limit.
+
+    Bandwidth is computed as `freq_slope × T_s` (see
+    [`XWRConfig.bandwidth`][xwr.config.XWRConfig]).
+
+    | Device | Maximum |
+    |--------|---------|
+    """
+
+    _LIMITS: ClassVar[dict[str, float]] = {}
+
+    @staticmethod
+    def check(radar, capture=None):
+        limit = MaxBandwidth._LIMITS.get(radar.device_name)
+        if limit is None:
+            return ConstraintCheck(
+                MaxBandwidth, None,
+                f"not checked for {radar.device_name}")
+        passed = radar.bandwidth <= limit
+        detail = f"bandwidth = {radar.bandwidth:.1f} MHz, maximum = {limit:.1f} MHz"
+        if not passed:
+            detail = (
+                f"bandwidth = {radar.bandwidth:.1f} MHz "
+                f"> device maximum {limit:.1f} MHz")
+        return ConstraintCheck(MaxBandwidth, passed, detail)
+
+
+class NetworkUtilization(Constraint):
+    """Radar data throughput must not exceed 80% of capture card capacity.
+
+    High utilization risks packet loss in the networking:
+
+        radar.throughput / capture.throughput < 80%
+
+    Skipped if no [`DCAConfig`][xwr.config.] is provided.
+    """
+
+    @staticmethod
+    def check(radar, capture=None):
+        if capture is None:
+            return ConstraintCheck(
+                NetworkUtilization, None, "no capture config provided")
+        util = 100 * radar.throughput / capture.throughput
+        passed = util < 80
+        detail = (
+            f"network utilization = {util:.1f}% "
+            f"(radar {int(radar.throughput / 1e6)} Mbps "
+            f"/ capture {int(capture.throughput / 1e6)} Mbps)")
+        if not passed:
+            detail += " (must be < 80%)"
+        return ConstraintCheck(NetworkUtilization, passed, detail)
+
+
+class ReceiveBuffer(Constraint):
+    """OS receive buffer must hold at least two full radar frames.
+
+    Since radar frames are transmitted by the capture card in consecutive
+    bursts of packets, a buffer smaller than two frames risks dropping packets
+    when the consumer falls momentarily behind:
+
+        socket_buffer / frame_size ≥ 2
+
+    Skipped if no [`DCAConfig`][xwr.config.] is provided.
+    """
+
+    @staticmethod
+    def check(radar, capture=None):
+        if capture is None:
+            return ConstraintCheck(
+                ReceiveBuffer, None, "no capture config provided")
+        ratio = capture.socket_buffer / radar.frame_size
+        passed = ratio > 2.0
+        detail = (
+            f"recv buffer = {capture.socket_buffer} bytes "
+            f"= {ratio:.2f} frames (1 frame = {radar.frame_size} bytes)"
+            + (" (must be > 2)" if not passed else ""))
+        return ConstraintCheck(ReceiveBuffer, passed, detail)
+
+
+def check_config(
+    radar: XWRConfig,
+    capture: DCAConfig | None = None,
+) -> list[ConstraintCheck]:
+    """Run all constraints against a configuration.
+
+    Args:
+        radar: radar configuration.
+        capture: capture card configuration; cross-config constraints are
+            skipped if not provided.
+
+    Returns:
+        All constraint results, including passed and skipped checks.
+    """
+    CONSTRAINTS: list[type[Constraint]] = [
+        DutyCycle,
+        ExcessRampTime,
+        CubeSizeLimit,
+        FrameLengthPowerOfTwo,
+        AdcSamplesPowerOfTwo,
+        MaxSampleRate,
+        MinSampleRate,
+        MaxBandwidth,
+        NetworkUtilization,
+        ReceiveBuffer,
+    ]
+    return [C.check(radar, capture) for C in CONSTRAINTS]

--- a/src/xwr/constraints.py
+++ b/src/xwr/constraints.py
@@ -183,6 +183,11 @@ class FrameLengthPowerOfTwo(Constraint):
     @staticmethod
     def check(radar, capture=None):
         fl = radar.frame_length
+        if fl == 0:
+            return ConstraintCheck(
+                FrameLengthPowerOfTwo, False,
+                "frame_length = 0 (must be nonzero)")
+
         passed = fl & (fl - 1) == 0
         detail = f"frame_length = {fl}"
         if not passed:
@@ -202,6 +207,11 @@ class AdcSamplesPowerOfTwo(Constraint):
     @staticmethod
     def check(radar, capture=None):
         n = radar.adc_samples
+        if n == 0:
+            return ConstraintCheck(
+                AdcSamplesPowerOfTwo, False,
+                "adc_samples = 0 (must be nonzero)")
+
         passed = n & (n - 1) == 0
         detail = f"adc_samples = {n}"
         if not passed:
@@ -399,11 +409,11 @@ class ReceiveBuffer(Constraint):
             return ConstraintCheck(
                 ReceiveBuffer, None, "no capture config provided")
         ratio = capture.socket_buffer / radar.frame_size
-        passed = ratio > 2.0
+        passed = ratio >= 2.0
         detail = (
             f"recv buffer = {capture.socket_buffer} bytes "
             f"= {ratio:.2f} frames (1 frame = {radar.frame_size} bytes)"
-            + (" (must be > 2)" if not passed else ""))
+            + (" (should be >= 2)" if not passed else ""))
         return ConstraintCheck(ReceiveBuffer, passed, detail)
 
 

--- a/src/xwr/constraints.py
+++ b/src/xwr/constraints.py
@@ -7,6 +7,23 @@ This module documents and enforces known constraints on radar configurations.
     These constraints are not exhaustive or guaranteed to be correct. If you
     find a missing constraint, or run into an undocumented or incorrectly
     implemented check, please open an issue!
+
+## Summary
+
+| Constraint | Description |
+|------------|-------------|
+| [`FrameDutyCycle`][.] | Active transmit time < 99% of frame period |
+| [`RFDutyCycle`][.] | RF on-time < 50% of frame period |
+| [`ExcessRampTime`][.] | ADC window must complete before ramp ends |
+| [`CubeSizeLimit`][.] | Data cube must fit in device L3 buffer |
+| [`FrameLengthPowerOfTwo`][.] | Frame length: power of 2 |
+| [`AdcSamplesPowerOfTwo`][.] | ADC samples: power of 2 |
+| [`MaxSampleRate`][.] | ADC sample rate ≤ device maximum |
+| [`MinSampleRate`][.] | ADC sample rate ≥ device minimum |
+| [`FrequencyRange`][.] | Start/end frequency within device RF band |
+| [`MaxBandwidth`][.] | Chirp bandwidth ≤ device RF maximum |
+| [`NetworkUtilization`][.] | Radar throughput < 80% of capture |
+| [`ReceiveBuffer`][.] | Receive buffer must hold ≥ 2 radar frames |
 """
 
 import logging

--- a/src/xwr/constraints.py
+++ b/src/xwr/constraints.py
@@ -9,6 +9,7 @@ This module documents and enforces known constraints on radar configurations.
     implemented check, please open an issue!
 """
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import ClassVar
@@ -44,7 +45,7 @@ class ConstraintCheck:
     detail: str
 
 
-class DutyCycle(Constraint):
+class FrameDutyCycle(Constraint):
     """Active frame time must not exceed the frame period.
 
     The fraction of each period spent actively transmitting must stay
@@ -60,10 +61,31 @@ class DutyCycle(Constraint):
     def check(radar, capture=None):
         duty_cycle = 100 * radar.frame_time / radar.frame_period
         passed = duty_cycle < 99
-        detail = f"duty cycle = {duty_cycle:.1f}%"
+        detail = f"frame duty cycle = {duty_cycle:.1f}%"
         if not passed:
             detail += " (must be < 99%)"
-        return ConstraintCheck(DutyCycle, passed, detail)
+        return ConstraintCheck(FrameDutyCycle, passed, detail)
+
+
+class RFDutyCycle(Constraint):
+    """RF transmitter on-time must not exceed 50% of the frame period.
+
+    Counts only the time the RF ramp is active (`ramp_end_time` per TX
+    per chirp), excluding idle time and the inter-frame gap:
+
+        ramp_end_time × num_tx × frame_length / (frame_period × 1000) < 50%
+    """
+
+    @staticmethod
+    def check(radar, capture=None):
+        rf_on_us = radar.ramp_end_time * radar.num_tx * radar.frame_length
+        period_us = radar.frame_period * 1e3
+        duty_cycle = 100 * rf_on_us / period_us
+        passed = duty_cycle < 50
+        detail = f"RF duty cycle = {duty_cycle:.1f}%"
+        if not passed:
+            detail += " (should be < 50%)"
+        return ConstraintCheck(RFDutyCycle, passed, detail)
 
 
 class ExcessRampTime(Constraint):
@@ -234,17 +256,71 @@ class MinSampleRate(Constraint):
         return ConstraintCheck(MinSampleRate, passed, detail)
 
 
+class FrequencyRange(Constraint):
+    """Start and end frequencies must lie within the device RF band.
+
+    Both the start frequency and the end frequency
+    (`start_freq + bandwidth / 1000`) are checked against per-device limits:
+
+    | Device   | Min (GHz) | Max (GHz) |
+    |----------|-----------|-----------|
+    | AWR1642  | 76        | 81        |
+    | AWR1843  | 76        | 81        |
+    | AWR2944  | 76        | 81        |
+    | AWRL6844 | 57        | 64        |
+    """
+
+    _LIMITS: ClassVar[dict[str, tuple[float, float]]] = {
+        "AWR1642":  (76.0, 81.0),
+        "AWR1843":  (76.0, 81.0),
+        "AWR1843L": (76.0, 81.0),
+        "AWR2944":  (76.0, 81.0),
+        "AWRL6844": (57.0, 64.0),
+    }
+
+    @staticmethod
+    def check(radar, capture=None):
+        limits = FrequencyRange._LIMITS.get(radar.device_name)
+        if limits is None:
+            return ConstraintCheck(
+                FrequencyRange, None,
+                f"not checked for {radar.device_name}")
+        min_freq, max_freq = limits
+        start = radar.frequency
+        end = radar.frequency + radar.bandwidth / 1000
+        if start < min_freq:
+            return ConstraintCheck(
+                FrequencyRange, False,
+                f"start frequency {start:.3f} GHz < device minimum {min_freq} GHz")
+        if end > max_freq:
+            return ConstraintCheck(
+                FrequencyRange, False,
+                f"end frequency {end:.3f} GHz > device maximum {max_freq} GHz")
+        return ConstraintCheck(
+            FrequencyRange, True,
+            f"frequency range {start:.3f}–{end:.3f} GHz "
+            f"(device band {min_freq}–{max_freq} GHz)")
+
+
 class MaxBandwidth(Constraint):
     """Effective chirp bandwidth must not exceed the device RF limit.
 
     Bandwidth is computed as `freq_slope × T_s` (see
     [`XWRConfig.bandwidth`][xwr.config.XWRConfig]).
 
-    | Device | Maximum |
-    |--------|---------|
+    | Device   | Maximum  |
+    |----------|----------|
+    | AWR1642  | 4000 MHz |
+    | AWR1843  | 4000 MHz |
+    | AWR2944  | 4000 MHz |
     """
 
-    _LIMITS: ClassVar[dict[str, float]] = {}
+    _LIMITS: ClassVar[dict[str, float]] = {
+        "AWR1642":  4000.0,
+        "AWR1843":  4000.0,
+        "AWR1843L": 4000.0,
+        "AWR2944":  4000.0,
+    }
 
     @staticmethod
     def check(radar, capture=None):
@@ -254,11 +330,11 @@ class MaxBandwidth(Constraint):
                 MaxBandwidth, None,
                 f"not checked for {radar.device_name}")
         passed = radar.bandwidth <= limit
-        detail = f"bandwidth = {radar.bandwidth:.1f} MHz, maximum = {limit:.1f} MHz"
+        detail = f"bandwidth = {radar.bandwidth:.1f} MHz, maximum = {limit:.0f} MHz"
         if not passed:
             detail = (
                 f"bandwidth = {radar.bandwidth:.1f} MHz "
-                f"> device maximum {limit:.1f} MHz")
+                f"> device maximum {limit:.0f} MHz")
         return ConstraintCheck(MaxBandwidth, passed, detail)
 
 
@@ -317,6 +393,7 @@ class ReceiveBuffer(Constraint):
 def check_config(
     radar: XWRConfig,
     capture: DCAConfig | None = None,
+    log: bool = True,
 ) -> list[ConstraintCheck]:
     """Run all constraints against a configuration.
 
@@ -324,20 +401,35 @@ def check_config(
         radar: radar configuration.
         capture: capture card configuration; cross-config constraints are
             skipped if not provided.
+        log: if `True`, log each result at INFO level (pass/skip) or WARNING
+            level (fail) using the `xwr/constraints` logger.
 
     Returns:
         All constraint results, including passed and skipped checks.
     """
     CONSTRAINTS: list[type[Constraint]] = [
-        DutyCycle,
+        FrameDutyCycle,
+        RFDutyCycle,
         ExcessRampTime,
         CubeSizeLimit,
         FrameLengthPowerOfTwo,
         AdcSamplesPowerOfTwo,
         MaxSampleRate,
         MinSampleRate,
+        FrequencyRange,
         MaxBandwidth,
         NetworkUtilization,
         ReceiveBuffer,
     ]
-    return [C.check(radar, capture) for C in CONSTRAINTS]
+    results = [C.check(radar, capture) for C in CONSTRAINTS]
+    if log:
+        logger = logging.getLogger("xwr/constraints")
+        for r in results:
+            name = r.constraint.__name__
+            if r.passed is False:
+                logger.warning(f"Possibly invalid - {name}: {r.detail}")
+            else:
+                logger.info(
+                    f"{'skipped' if r.passed is None else 'pass'}"
+                    f" | {name}: {r.detail}")
+    return results

--- a/src/xwr/radar/api.py
+++ b/src/xwr/radar/api.py
@@ -56,8 +56,6 @@ class AWR1843(XWRBase, common.APIMixins):
             frame_length: chirps per frame per TX antenna. Must be a power of 2.
             frame_period: time between the start of each frame; in ms.
         """
-        assert frame_length & (frame_length - 1) == 0
-
         self.stop()
         self.send("flushCfg")
         self.send("dfeDataOutputMode {modeType.value}".format(
@@ -152,8 +150,6 @@ class AWR1642(XWRBase, common.APIMixins):
             frame_length: chirps per frame per TX antenna. Must be a power of 2.
             frame_period: time between the start of each frame; in ms.
         """
-        assert frame_length & (frame_length - 1) == 0
-
         self.stop()
         self.send("flushCfg")
         self.send("dfeDataOutputMode {modeType.value}".format(
@@ -229,8 +225,6 @@ class AWR2944(XWRBase, common.APIMixins):
             frame_length: chirps per frame per TX antenna. Must be a power of 2.
             frame_period: time between the start of each frame; in ms.
         """
-        assert frame_length & (frame_length - 1) == 0
-
         self.port.write('\n'.encode('ascii'))
         self._wait_for_response()
 
@@ -324,8 +318,6 @@ class AWRL6844(XWRBase):
                 Must be a power of 2.
             frame_period: time between the start of each frame; in ms.
         """
-        assert frame_length & (frame_length - 1) == 0
-
         self.port.write('\n'.encode('ascii'))
         self._wait_for_response()
 

--- a/src/xwr/radar/base.py
+++ b/src/xwr/radar/base.py
@@ -76,7 +76,7 @@ class XWRBase:
         self, port: str | None = None, baudrate: int = 115200,
         name: str = "AWR1843"
     ) -> None:
-        self.log: logging.Logger = logging.getLogger(name=name)
+        self.log: logging.Logger = logging.getLogger(name=f"xwr/{name}")
 
         if port is None:
             port = self.__detect_port()

--- a/src/xwr/system.py
+++ b/src/xwr/system.py
@@ -41,19 +41,9 @@ class XWRSystem(Generic[TRadar]):
 
     !!! info "Known Constraints"
 
-        The `XWRSystem` will check for certain known constraints, and warn if
-        these are violated via a logger:
-
-        - Radar data throughput is greater than 80% of the capture card
-            theoretical network throughput.
-        - Receive buffer size (in the linux networking stack) can hold less
-            than 2 full frames.
-        - The duty cycle (active frame time / frame period) of the radar is
-            greater than 99%.
-        - The ADC is still sampling when the ramp ends.
-        - The range-Doppler frame size is greater than 2^14.
-        - The number of samples per chirp (i.e., range resolution) or chirps
-            per frame (i.e., doppler resolution) is not a power of 2.
+        The `XWRSystem` will check for known constraints on initialization,
+        and warn or raise if any are violated. See
+        [`xwr.constraints`][xwr.constraints] for the full list.
 
     Type Parameters:
         - `TRadar`: radar type (subclass of [`XWRBase`][xwr.radar.])
@@ -88,47 +78,19 @@ class XWRSystem(Generic[TRadar]):
         self.config = radar
         self.fps: float = 1000.0 / radar.frame_period
 
-    def _assert(self, cond: bool, desc: str) -> None:
-        """Check a condition and log (or raise) a warning if it is not met."""
-        if not cond:
-            if self.strict:
-                raise ValueError(f"Potentially invalid configuration: {desc}")
-            self.log.warning(f"Invalid radar configuration: {desc}")
-        else:
-            self.log.debug(f"Passed check: {desc}")
-
     def _check_config(self, radar: XWRConfig, capture: DCAConfig) -> None:
         """Check config, and warn if potentially invalid."""
-        util = 100 * radar.throughput / capture.throughput
-        self.log.info(
-            f"Radar/Capture card throughput: {int(radar.throughput / 1e6)} "
-            f"Mbps / {int(capture.throughput / 1e6)} Mbps ({util:.1f}%)")
-        self._assert(util < 80, f"Network utilization > 80%: {util:.1f}%")
-
-        ratio = capture.socket_buffer / radar.frame_size
-        self.log.info("Recv buffer size: {:.2f} frames".format(ratio))
-        self._assert(ratio > 2.0,
-            f"Recv buffer < 2 frames: {capture.socket_buffer} "
-            f"(1 frame = {radar.frame_size})")
-
-        duty_cycle = 100 * radar.frame_time / radar.frame_period
-        self.log.info(f"Radar duty cycle: {duty_cycle:.1f}%")
-        self._assert(duty_cycle < 99, f"Duty cycle > 99%: {duty_cycle:.1f}%")
-
-        excess = radar.ramp_end_time - radar.adc_start_time - radar.sample_time
-        self.log.info(f"Excess ramp time: {excess:.1f}us")
-        self._assert(excess >= 0, f"Excess ramp time < 0: {excess:.1f}us")
-
-        frame_size = radar.frame_length * radar.adc_samples
-        self.log.info(
-            f"Range-Doppler size: {radar.frame_length} x "
-            f"{radar.adc_samples} = {frame_size}")
-        self._assert(frame_size <= 2**14,
-            f"Range-doppler frame size > 2^14: {frame_size}")
-        self._assert(radar.frame_length & (radar.frame_length - 1) == 0,
-            f"Frame length not a power of 2: {radar.frame_length}")
-        self._assert(radar.adc_samples & (radar.adc_samples - 1) == 0,
-            f"ADC samples not a power of 2: {radar.adc_samples}")
+        from .constraints import check_config
+        for r in check_config(radar, capture):
+            name = r.constraint.__name__
+            if r.passed is False:
+                if self.strict:
+                    raise ValueError(
+                        f"Invalid configuration - {name}: {r.detail}")
+                self.log.warning(f"Invalid configuration - {name}: {r.detail}")
+            else:
+                self.log.debug(f"{'Skipped' if r.passed is None else 'Passed'}"
+                               f" - {name}: {r.detail}")
 
     def stream(self) -> Iterator[types.RadarFrame]:
         """Iterator which yields successive frames.

--- a/src/xwr/system.py
+++ b/src/xwr/system.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from .capture import DCA1000EVM, types
 from .config import DCAConfig, XWRConfig
+from .constraints import check_config
 from .radar import XWRBase
 
 TRadar = TypeVar("TRadar", bound=XWRBase)
@@ -79,18 +80,11 @@ class XWRSystem(Generic[TRadar]):
         self.fps: float = 1000.0 / radar.frame_period
 
     def _check_config(self, radar: XWRConfig, capture: DCAConfig) -> None:
-        """Check config, and warn if potentially invalid."""
-        from .constraints import check_config
+        """Check config, and raise if strict mode is enabled and invalid."""
         for r in check_config(radar, capture):
-            name = r.constraint.__name__
-            if r.passed is False:
-                if self.strict:
-                    raise ValueError(
-                        f"Invalid configuration - {name}: {r.detail}")
-                self.log.warning(f"Invalid configuration - {name}: {r.detail}")
-            else:
-                self.log.debug(f"{'Skipped' if r.passed is None else 'Passed'}"
-                               f" - {name}: {r.detail}")
+            if r.passed is False and self.strict:
+                raise ValueError(
+                    f"Invalid configuration | {r.constraint.__name__}: {r.detail}")
 
     def stream(self) -> Iterator[types.RadarFrame]:
         """Iterator which yields successive frames.

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -9,13 +9,15 @@ from xwr.constraints import (
     AdcSamplesPowerOfTwo,
     ConstraintCheck,
     CubeSizeLimit,
-    DutyCycle,
     ExcessRampTime,
+    FrameDutyCycle,
     FrameLengthPowerOfTwo,
+    FrequencyRange,
     MaxBandwidth,
     MaxSampleRate,
     MinSampleRate,
     NetworkUtilization,
+    RFDutyCycle,
     ReceiveBuffer,
     check_config,
 )
@@ -74,16 +76,37 @@ def assert_skipped(r: ConstraintCheck):
 
 
 # ---------------------------------------------------------------------------
-# DutyCycle
+# FrameDutyCycle
 # ---------------------------------------------------------------------------
 
-def test_duty_cycle_pass(radar):
-    assert_passed(DutyCycle.check(radar))
+def test_frame_duty_cycle_pass(radar):
+    assert_passed(FrameDutyCycle.check(radar))
 
 
-def test_duty_cycle_fail(radar):
+def test_frame_duty_cycle_fail(radar):
     # frame_period barely less than frame_time → duty cycle > 99%
-    assert_failed(DutyCycle.check(replace(radar, frame_period=30.0)))
+    assert_failed(FrameDutyCycle.check(replace(radar, frame_period=30.0)))
+
+
+# ---------------------------------------------------------------------------
+# RFDutyCycle
+# ---------------------------------------------------------------------------
+
+def test_rf_duty_cycle_pass(radar):
+    # RF duty = 56 * 3 * 64 / (100 * 1000) = 10.75%
+    assert_passed(RFDutyCycle.check(radar))
+
+
+def test_rf_duty_cycle_fail(radar):
+    # ramp_end_time=300 → RF duty = 300 * 3 * 64 / (100 * 1000) = 57.6%
+    assert_failed(RFDutyCycle.check(replace(radar, ramp_end_time=300.0)))
+
+
+def test_rf_duty_cycle_at_boundary(radar):
+    # RF duty exactly 50% should fail (< 50% required)
+    # ramp_end_time = 0.5 * frame_period * 1000 / (num_tx * frame_length)
+    # = 0.5 * 100000 / (3 * 64) = 260.4167us → RF = 50.0%
+    assert_failed(RFDutyCycle.check(replace(radar, ramp_end_time=260.42)))
 
 
 # ---------------------------------------------------------------------------
@@ -198,13 +221,79 @@ def test_min_sample_rate_applies_to_awr1843l(radar):
 
 
 # ---------------------------------------------------------------------------
+# FrequencyRange
+# ---------------------------------------------------------------------------
+
+def test_frequency_range_pass(radar):
+    # start=77.0, end=77.0 + 3584/1000 = 80.584 GHz, within 76-81
+    assert_passed(FrequencyRange.check(radar))
+
+
+def test_frequency_range_fail_start_too_low(radar):
+    assert_failed(FrequencyRange.check(replace(radar, frequency=75.0)))
+
+
+def test_frequency_range_fail_end_too_high(radar):
+    # freq_slope=80 → bandwidth = 80 * 51.2 = 4096 MHz → end = 77 + 4.096 = 81.096 GHz
+    assert_failed(FrequencyRange.check(replace(radar, freq_slope=80.0)))
+
+
+def test_frequency_range_skip_unknown_device(radar):
+    class CustomRadar(AWR1843):
+        pass
+    assert_skipped(FrequencyRange.check(replace(radar, device=CustomRadar)))
+
+
+def test_frequency_range_awrl6844_pass(radar):
+    # AWRL6844 band: 57-64 GHz; end = 60.0 + 3.584 = 63.584 GHz
+    cfg = replace(radar, device=AWRL6844, frequency=60.0)
+    assert_passed(FrequencyRange.check(cfg))
+
+
+def test_frequency_range_awrl6844_fail_start_too_low(radar):
+    cfg = replace(radar, device=AWRL6844, frequency=56.0)
+    assert_failed(FrequencyRange.check(cfg))
+
+
+def test_frequency_range_awrl6844_fail_end_too_high(radar):
+    # frequency=62.0, freq_slope=80 → end = 62.0 + 4.096 = 66.096 GHz > 64
+    cfg = replace(radar, device=AWRL6844, frequency=62.0, freq_slope=80.0)
+    assert_failed(FrequencyRange.check(cfg))
+
+
+def test_frequency_range_all_76ghz_devices(radar):
+    # AWR1642, AWR1843, AWR2944 all use the 76-81 GHz band
+    for device in [AWR1642, AWR1843, AWR1843L, AWR2944]:
+        assert_passed(FrequencyRange.check(replace(radar, device=device)))
+
+
+# ---------------------------------------------------------------------------
 # MaxBandwidth
 # ---------------------------------------------------------------------------
 
-def test_max_bandwidth_skip_all(radar):
-    # _LIMITS is empty — all devices skip
-    for device in [AWR1642, AWR1843, AWR1843L, AWR2944, AWRL6844]:
-        assert_skipped(MaxBandwidth.check(replace(radar, device=device)))
+def test_max_bandwidth_pass(radar):
+    # bandwidth = 70 * 51.2 = 3584 MHz < 4000 MHz
+    assert_passed(MaxBandwidth.check(radar))
+
+
+def test_max_bandwidth_fail(radar):
+    # freq_slope=80 → bandwidth = 80 * 51.2 = 4096 MHz > 4000 MHz
+    assert_failed(MaxBandwidth.check(replace(radar, freq_slope=80.0)))
+
+
+def test_max_bandwidth_at_limit(radar):
+    # freq_slope = 4000 / 51.2 = 78.125 → bandwidth exactly 4000 MHz (pass)
+    assert_passed(MaxBandwidth.check(replace(radar, freq_slope=78.125)))
+
+
+def test_max_bandwidth_skip_awrl6844(radar):
+    # AWRL6844 has no MaxBandwidth entry; FrequencyRange enforces its limits
+    assert_skipped(MaxBandwidth.check(replace(radar, device=AWRL6844)))
+
+
+def test_max_bandwidth_applies_to_awr1642(radar):
+    cfg = replace(radar, device=AWR1642, freq_slope=80.0)
+    assert_failed(MaxBandwidth.check(cfg))
 
 
 # ---------------------------------------------------------------------------
@@ -247,20 +336,34 @@ def test_receive_buffer_skip_no_capture(radar):
 # ---------------------------------------------------------------------------
 
 def test_check_config_all_pass(radar, capture):
-    results = check_config(radar, capture)
+    results = check_config(radar, capture, log=False)
     failures = [r for r in results if r.passed is False]
     assert not failures, f"Unexpected failures: {failures}"
 
 
 def test_check_config_returns_all_constraints(radar, capture):
-    results = check_config(radar, capture)
-    assert len(results) == 10  # one per constraint class
+    results = check_config(radar, capture, log=False)
+    assert len(results) == 12  # one per constraint class
     assert all(isinstance(r, ConstraintCheck) for r in results)
 
 
 def test_check_config_no_capture_skips_cross_config(radar):
-    results = check_config(radar, capture=None)
+    results = check_config(radar, capture=None, log=False)
     cross_config = {NetworkUtilization, ReceiveBuffer}
     for r in results:
         if r.constraint in cross_config:
             assert r.passed is None
+
+
+def test_check_config_no_log(radar, capture, caplog):
+    import logging
+    with caplog.at_level(logging.DEBUG, logger="xwr/constraints"):
+        check_config(radar, capture, log=False)
+    assert not caplog.records
+
+
+def test_check_config_log(radar, capture, caplog):
+    import logging
+    with caplog.at_level(logging.DEBUG, logger="xwr/constraints"):
+        check_config(radar, capture, log=True)
+    assert caplog.records

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,266 @@
+"""Tests for xwr.constraints."""
+
+import dataclasses
+
+import pytest
+
+from xwr.config import DCAConfig, XWRConfig
+from xwr.constraints import (
+    AdcSamplesPowerOfTwo,
+    ConstraintCheck,
+    CubeSizeLimit,
+    DutyCycle,
+    ExcessRampTime,
+    FrameLengthPowerOfTwo,
+    MaxBandwidth,
+    MaxSampleRate,
+    MinSampleRate,
+    NetworkUtilization,
+    ReceiveBuffer,
+    check_config,
+)
+from xwr.radar import AWR1642, AWR1843, AWR1843L, AWR2944, AWRL6844
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def radar():
+    """A valid AWR1843 config that passes all constraints."""
+    return XWRConfig(
+        device=AWR1843,
+        frequency=77.0,
+        idle_time=110.0,
+        adc_start_time=4.0,
+        ramp_end_time=56.0,   # excess = 56 - 4 - 51.2 = 0.8us
+        tx_start_time=1.0,
+        freq_slope=70.0,
+        adc_samples=256,       # power of two; sample_time = 51.2us
+        sample_rate=5_000,     # 5 Ksps, within [2000, 25000]
+        frame_length=64,       # power of two; duty cycle ~32%
+        frame_period=100.0,
+    )
+
+
+@pytest.fixture
+def capture():
+    """A valid DCAConfig that passes all cross-config constraints."""
+    return DCAConfig()
+
+
+def replace(cfg, **kwargs):
+    return dataclasses.replace(cfg, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def result_for(constraint, radar, capture=None):
+    return constraint.check(radar, capture)
+
+
+def assert_passed(r: ConstraintCheck):
+    assert r.passed is True, f"Expected pass, got: {r}"
+
+
+def assert_failed(r: ConstraintCheck):
+    assert r.passed is False, f"Expected fail, got: {r}"
+
+
+def assert_skipped(r: ConstraintCheck):
+    assert r.passed is None, f"Expected skip, got: {r}"
+
+
+# ---------------------------------------------------------------------------
+# DutyCycle
+# ---------------------------------------------------------------------------
+
+def test_duty_cycle_pass(radar):
+    assert_passed(DutyCycle.check(radar))
+
+
+def test_duty_cycle_fail(radar):
+    # frame_period barely less than frame_time → duty cycle > 99%
+    assert_failed(DutyCycle.check(replace(radar, frame_period=30.0)))
+
+
+# ---------------------------------------------------------------------------
+# ExcessRampTime
+# ---------------------------------------------------------------------------
+
+def test_excess_ramp_time_pass(radar):
+    assert_passed(ExcessRampTime.check(radar))
+
+
+def test_excess_ramp_time_fail(radar):
+    # ramp_end_time < adc_start_time + sample_time
+    assert_failed(ExcessRampTime.check(replace(radar, ramp_end_time=10.0)))
+
+
+# ---------------------------------------------------------------------------
+# CubeSizeLimit
+# ---------------------------------------------------------------------------
+
+def test_cube_size_limit_pass(radar):
+    # AWR1843: frame_size = 64*3*4*256*4 = 786432 < 1MiB
+    assert_passed(CubeSizeLimit.check(radar))
+
+
+def test_cube_size_limit_fail(radar):
+    # Push frame_length up so frame_size > 1 MiB (AWR1843 limit)
+    # frame_size = 128 * 3 * 4 * 256 * 4 = 1572864 > 1048576
+    assert_failed(CubeSizeLimit.check(replace(radar, frame_length=128)))
+
+
+def test_cube_size_limit_awr2944_larger_buffer(radar):
+    # Same frame_length=128 passes on AWR2944 (2.5 MiB limit, 2-byte samples)
+    # frame_size = 128 * 4 * 4 * 256 * 2 = 1048576 < 2.5 MiB
+    cfg = replace(radar, device=AWR2944, frame_length=128)
+    assert_passed(CubeSizeLimit.check(cfg))
+
+
+def test_cube_size_limit_skip_unknown_device(radar):
+    class CustomRadar(AWR1843):
+        pass
+    assert_skipped(CubeSizeLimit.check(replace(radar, device=CustomRadar)))
+
+
+# ---------------------------------------------------------------------------
+# FrameLengthPowerOfTwo
+# ---------------------------------------------------------------------------
+
+def test_frame_length_power_of_two_pass(radar):
+    assert_passed(FrameLengthPowerOfTwo.check(radar))
+
+
+def test_frame_length_power_of_two_fail(radar):
+    assert_failed(FrameLengthPowerOfTwo.check(replace(radar, frame_length=48)))
+
+
+# ---------------------------------------------------------------------------
+# AdcSamplesPowerOfTwo
+# ---------------------------------------------------------------------------
+
+def test_adc_samples_power_of_two_pass(radar):
+    assert_passed(AdcSamplesPowerOfTwo.check(radar))
+
+
+def test_adc_samples_power_of_two_fail(radar):
+    assert_failed(AdcSamplesPowerOfTwo.check(replace(radar, adc_samples=300)))
+
+
+# ---------------------------------------------------------------------------
+# MaxSampleRate
+# ---------------------------------------------------------------------------
+
+def test_max_sample_rate_pass(radar):
+    assert_passed(MaxSampleRate.check(radar))
+
+
+def test_max_sample_rate_fail_awr1642(radar):
+    cfg = replace(radar, device=AWR1642, sample_rate=20_000)
+    assert_failed(MaxSampleRate.check(cfg))
+
+
+def test_max_sample_rate_at_limit(radar):
+    assert_passed(MaxSampleRate.check(replace(radar, sample_rate=25_000)))
+
+
+def test_max_sample_rate_skip_unknown(radar):
+    class CustomRadar(AWR1843):
+        pass
+    assert_skipped(MaxSampleRate.check(replace(radar, device=CustomRadar)))
+
+
+# ---------------------------------------------------------------------------
+# MinSampleRate
+# ---------------------------------------------------------------------------
+
+def test_min_sample_rate_pass(radar):
+    assert_passed(MinSampleRate.check(radar))
+
+
+def test_min_sample_rate_fail(radar):
+    assert_failed(MinSampleRate.check(replace(radar, sample_rate=1_000)))
+
+
+def test_min_sample_rate_skip_awr1642(radar):
+    # AWR1642 has no minimum sample rate
+    cfg = replace(radar, device=AWR1642, sample_rate=1_000)
+    assert_skipped(MinSampleRate.check(cfg))
+
+
+def test_min_sample_rate_applies_to_awr1843l(radar):
+    cfg = replace(radar, device=AWR1843L, sample_rate=1_000)
+    assert_failed(MinSampleRate.check(cfg))
+
+
+# ---------------------------------------------------------------------------
+# MaxBandwidth
+# ---------------------------------------------------------------------------
+
+def test_max_bandwidth_skip_all(radar):
+    # _LIMITS is empty — all devices skip
+    for device in [AWR1642, AWR1843, AWR1843L, AWR2944, AWRL6844]:
+        assert_skipped(MaxBandwidth.check(replace(radar, device=device)))
+
+
+# ---------------------------------------------------------------------------
+# NetworkUtilization
+# ---------------------------------------------------------------------------
+
+def test_network_utilization_pass(radar, capture):
+    assert_passed(NetworkUtilization.check(radar, capture))
+
+
+def test_network_utilization_fail(radar, capture):
+    # Increase frame rate so radar throughput exceeds 80% of capture card
+    assert_failed(NetworkUtilization.check(replace(radar, frame_period=1.0), capture))
+
+
+def test_network_utilization_skip_no_capture(radar):
+    assert_skipped(NetworkUtilization.check(radar, None))
+
+
+# ---------------------------------------------------------------------------
+# ReceiveBuffer
+# ---------------------------------------------------------------------------
+
+def test_receive_buffer_pass(radar, capture):
+    assert_passed(ReceiveBuffer.check(radar, capture))
+
+
+def test_receive_buffer_fail(radar, capture):
+    # socket_buffer smaller than 2 frames
+    small_capture = replace(capture, socket_buffer=radar.frame_size)
+    assert_failed(ReceiveBuffer.check(radar, small_capture))
+
+
+def test_receive_buffer_skip_no_capture(radar):
+    assert_skipped(ReceiveBuffer.check(radar, None))
+
+
+# ---------------------------------------------------------------------------
+# check_config integration
+# ---------------------------------------------------------------------------
+
+def test_check_config_all_pass(radar, capture):
+    results = check_config(radar, capture)
+    failures = [r for r in results if r.passed is False]
+    assert not failures, f"Unexpected failures: {failures}"
+
+
+def test_check_config_returns_all_constraints(radar, capture):
+    results = check_config(radar, capture)
+    assert len(results) == 10  # one per constraint class
+    assert all(isinstance(r, ConstraintCheck) for r in results)
+
+
+def test_check_config_no_capture_skips_cross_config(radar):
+    results = check_config(radar, capture=None)
+    cross_config = {NetworkUtilization, ReceiveBuffer}
+    for r in results:
+        if r.constraint in cross_config:
+            assert r.passed is None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1915,7 +1915,7 @@ wheels = [
 
 [[package]]
 name = "xwr"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Add constraint system for documenting and checking known and reverse-engineered constraints (#42):
- A new `xwr.constraints` module (non-exported) has constraint classes with documentation and checks for each rule.
- The checks are run by `XWRSystem` via `check_config`.
- The docs for each rule are built to a new `constraints.md` page.

Miscellaneous changes:
- Version bump
- Add a 3.14 tag (tested and works)
- Docs tweaks