### PR TITLE
Add RSP sample_swap

### DIFF
--- a/src/xwr/rsp/__init__.py
+++ b/src/xwr/rsp/__init__.py
@@ -5,6 +5,15 @@
     Elevation and azimuth axes are in "image order": increasing index is
     down and to the right, respectively.
 
+??? question "Byte order: when do I `sample_swap`?"
+
+    If you are using the `xwr` stack, use the default `sample_swap=False`,
+    which corresponds to [`MSB_LSB_IQ`][xwr.radar.defines.SampleSwap], the only
+    option supported by the source-available TI firmware. If processing data
+    collected using other systems (in particular, mmWave studio, which has its
+    own closed-source firmware which supports `MSB_LSB_QI`), you may need to
+    set `sample_swap=True` if this option was enabled.
+
 To use the RSP:
 
 1. Pick your backend. Currently, we support numpy, jax, and pytorch.

--- a/src/xwr/rsp/generic.py
+++ b/src/xwr/rsp/generic.py
@@ -60,7 +60,8 @@ TArray = TypeVar("TArray", bound=ArrayLike)
 
 
 def iqiq_from_iiqq(
-    iiqq: Int16[TArray, "... n"]
+    iiqq: Int16[TArray, "... n"],
+    sample_swap: bool = False,
 ) -> Int16[TArray, "... n/2 2"]:
     """Un-interleave IIQQ data.
 
@@ -70,21 +71,23 @@ def iqiq_from_iiqq(
 
     Args:
         iiqq: interleaved IIQQ data; see [`RadarFrame`][xwr.capture.types.].
+        sample_swap: if `True`, swap the I and Q components in the output.
 
     Returns:
         IQ data in an uninterleaved format with a trailing I/Q axis.
     """
     shape = (*iiqq.shape[:-1], iiqq.shape[-1] // 2)
+    i_idx, q_idx = (1, 0) if sample_swap else (0, 1)
 
     backend = _check_backend(iiqq)
     if backend == "numpy":
         assert isinstance(iiqq, np.ndarray)
 
         iq = np.zeros((*shape, 2), dtype=np.int16)
-        iq[..., 0::2, 1] = iiqq[..., 0::4]
-        iq[..., 1::2, 1] = iiqq[..., 1::4]
-        iq[..., 0::2, 0] = iiqq[..., 2::4]
-        iq[..., 1::2, 0] = iiqq[..., 3::4]
+        iq[..., 0::2, q_idx] = iiqq[..., 0::4]
+        iq[..., 1::2, q_idx] = iiqq[..., 1::4]
+        iq[..., 0::2, i_idx] = iiqq[..., 2::4]
+        iq[..., 1::2, i_idx] = iiqq[..., 3::4]
         return cast(Int16[TArray, "... n/2 2"], iq)
 
     elif backend == "jax":
@@ -93,10 +96,10 @@ def iqiq_from_iiqq(
 
         iq = jnp.zeros(
             (*shape, 2), dtype=jnp.int16
-        ).at[..., 0::2, 1].set(iiqq[..., 0::4]
-        ).at[..., 1::2, 1].set(iiqq[..., 1::4]
-        ).at[..., 0::2, 0].set(iiqq[..., 2::4]
-        ).at[..., 1::2, 0].set(iiqq[..., 3::4])
+        ).at[..., 0::2, q_idx].set(iiqq[..., 0::4]
+        ).at[..., 1::2, q_idx].set(iiqq[..., 1::4]
+        ).at[..., 0::2, i_idx].set(iiqq[..., 2::4]
+        ).at[..., 1::2, i_idx].set(iiqq[..., 3::4])
         return cast(Int16[TArray, "... n/2 2"], iq)
 
     else:  # backend == "torch"
@@ -104,17 +107,27 @@ def iqiq_from_iiqq(
         assert isinstance(iiqq, torch.Tensor)
 
         iq = torch.zeros((*shape, 2), dtype=torch.int16, device=iiqq.device)
-        iq[..., 0::2, 1] = iiqq[..., 0::4]
-        iq[..., 1::2, 1] = iiqq[..., 1::4]
-        iq[..., 0::2, 0] = iiqq[..., 2::4]
-        iq[..., 1::2, 0] = iiqq[..., 3::4]
+        iq[..., 0::2, q_idx] = iiqq[..., 0::4]
+        iq[..., 1::2, q_idx] = iiqq[..., 1::4]
+        iq[..., 0::2, i_idx] = iiqq[..., 2::4]
+        iq[..., 1::2, i_idx] = iiqq[..., 3::4]
         return cast(Int16[TArray, "... n/2 2"], iq)
 
 
 def iq_from_iiqq(
     iiqq: Int16[TArray, "... n"] | Complex64[TArray, "... _n"],
+    sample_swap: bool = False,
 ) -> Complex64[TArray, "... n2"]:
     """Un-interleave IIQQ data.
+
+    !!! info
+
+        The default `sample_swap = False` corresponds to the
+        [`MSB_LSB_IQ`][xwr.radar.defines.SampleSwap] byte order used by `xwr`.
+
+        In this case, `MSB_LSB_IQ` means that I is the MSB and Q is the LSB.
+        However, the data stream is little-endian, which means Q actually comes
+        before I, leading to the actual physical layout being QQII and so on.
 
     Type Parameters:
         - `TArray`: This function is multi-backend, and supports numpy
@@ -123,6 +136,8 @@ def iq_from_iiqq(
     Args:
         iiqq: interleaved IIQQ data; see [`RadarFrame`][xwr.capture.types.].
             If already complex, leave it as is.
+        sample_swap: if `True`, swap the I and Q components so that the
+            output is `Q + j*I` instead of `I + j*Q`.
 
     Returns:
         Complex IQ data.
@@ -136,8 +151,12 @@ def iq_from_iiqq(
         if iiqq.dtype == np.complex64:
             return iiqq
         iq = np.zeros(shape, dtype=np.complex64)
-        iq[..., 0::2] = 1j * iiqq[..., 0::4] + iiqq[..., 2::4]
-        iq[..., 1::2] = 1j * iiqq[..., 1::4] + iiqq[..., 3::4]
+        if sample_swap:
+            iq[..., 0::2] = iiqq[..., 0::4] + 1j * iiqq[..., 2::4]
+            iq[..., 1::2] = iiqq[..., 1::4] + 1j * iiqq[..., 3::4]
+        else:
+            iq[..., 0::2] = 1j * iiqq[..., 0::4] + iiqq[..., 2::4]
+            iq[..., 1::2] = 1j * iiqq[..., 1::4] + iiqq[..., 3::4]
         return cast(Complex64[TArray, "... n/2"], iq)
 
     elif backend == "jax":
@@ -146,10 +165,16 @@ def iq_from_iiqq(
 
         if iiqq.dtype == jnp.complex64:
             return iiqq
-        iq = jnp.zeros(
-            shape, dtype=jnp.complex64
-        ).at[..., 0::2].set(1j * iiqq[..., 0::4] + iiqq[..., 2::4]
-        ).at[..., 1::2].set(1j * iiqq[..., 1::4] + iiqq[..., 3::4])
+        if sample_swap:
+            iq = jnp.zeros(
+                shape, dtype=jnp.complex64
+            ).at[..., 0::2].set(iiqq[..., 0::4] + 1j * iiqq[..., 2::4]
+            ).at[..., 1::2].set(iiqq[..., 1::4] + 1j * iiqq[..., 3::4])
+        else:
+            iq = jnp.zeros(
+                shape, dtype=jnp.complex64
+            ).at[..., 0::2].set(1j * iiqq[..., 0::4] + iiqq[..., 2::4]
+            ).at[..., 1::2].set(1j * iiqq[..., 1::4] + iiqq[..., 3::4])
         return cast(Complex64[TArray, "... n/2"], iq)
 
     else: # backend == "torch"
@@ -159,8 +184,12 @@ def iq_from_iiqq(
         if iiqq.dtype == torch.complex64:
             return iiqq
         iq = torch.zeros(shape, dtype=torch.complex64, device=iiqq.device)
-        iq[..., 0::2] = 1j * iiqq[..., 0::4] + iiqq[..., 2::4]
-        iq[..., 1::2] = 1j * iiqq[..., 1::4] + iiqq[..., 3::4]
+        if sample_swap:
+            iq[..., 0::2] = iiqq[..., 0::4] + 1j * iiqq[..., 2::4]
+            iq[..., 1::2] = iiqq[..., 1::4] + 1j * iiqq[..., 3::4]
+        else:
+            iq[..., 0::2] = 1j * iiqq[..., 0::4] + iiqq[..., 2::4]
+            iq[..., 1::2] = 1j * iiqq[..., 1::4] + iiqq[..., 3::4]
         return cast(Complex64[TArray, "... n/2"], iq)
 
 
@@ -199,6 +228,8 @@ class RSP(ABC, Generic[TArray]):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     SAMPLE_TYPE: Literal["IQ", "I"] = "IQ"
@@ -207,7 +238,8 @@ class RSP(ABC, Generic[TArray]):
         self, window: bool | Mapping[
             Literal["range", "doppler", "azimuth", "elevation"], bool] = False,
         size: Mapping[
-            Literal["range", "doppler", "azimuth", "elevation"], int] = {}
+            Literal["range", "doppler", "azimuth", "elevation"], int] = {},
+        sample_swap: bool = False,
     ) -> None:
         self.window: dict[
             Literal["range", "doppler", "azimuth", "elevation"], bool]
@@ -222,6 +254,7 @@ class RSP(ABC, Generic[TArray]):
             self._default_window = False
 
         self.size = size
+        self.sample_swap = sample_swap
 
     @abstractmethod
     def fft(
@@ -348,7 +381,7 @@ class RSP(ABC, Generic[TArray]):
             Computed doppler-elevation-azimuth-range spectrum.
         """
         if self.SAMPLE_TYPE == "IQ":
-            x = iq_from_iiqq(x)
+            x = iq_from_iiqq(x, sample_swap=self.sample_swap)
         else:
             x = _to_float32(x)
 

--- a/src/xwr/rsp/jax/rsp.py
+++ b/src/xwr/rsp/jax/rsp.py
@@ -17,6 +17,8 @@ class RSPJax(RSP[Array], ABC):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def fft(
@@ -100,6 +102,8 @@ class AWR1843AOP(RSPJax):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not specified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(
@@ -131,6 +135,8 @@ class AWR1843Boost(RSPJax):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(
@@ -161,7 +167,7 @@ class AWR1843Boost(RSPJax):
             Estimated elevation angle of arrival (AoA) in radians for each
                 range-Doppler bin.
         """
-        iq = iq_from_iiqq(iq)
+        iq = iq_from_iiqq(iq, sample_swap=self.sample_swap)
         rd = self.doppler_range(iq)
         mimo = self.mimo_virtual_array(rd)[:, :, :, 2:-2]
 
@@ -189,6 +195,8 @@ class AWR1642Boost(RSPJax):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(

--- a/src/xwr/rsp/numpy/rsp.py
+++ b/src/xwr/rsp/numpy/rsp.py
@@ -20,15 +20,18 @@ class RSPNumpy(RSP[np.ndarray], ABC):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def __init__(
         self, window: bool | Mapping[
             Literal["range", "doppler", "azimuth", "elevation"], bool] = False,
         size: Mapping[
-            Literal["range", "doppler", "azimuth", "elevation"], int] = {}
+            Literal["range", "doppler", "azimuth", "elevation"], int] = {},
+        sample_swap: bool = False,
     ) -> None:
-        super().__init__(window=window, size=size)
+        super().__init__(window=window, size=size, sample_swap=sample_swap)
         self._fft_cache: dict[
             tuple[tuple[int, ...], tuple[int, ...], np.dtype], FFTW] = {}
 
@@ -101,6 +104,8 @@ class AWR1843AOP(RSPNumpy):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not specified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(
@@ -132,6 +137,8 @@ class AWR1843Boost(RSPNumpy):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(
@@ -166,6 +173,8 @@ class AWR1642Boost(RSPNumpy):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(

--- a/src/xwr/rsp/torch/rsp.py
+++ b/src/xwr/rsp/torch/rsp.py
@@ -19,6 +19,8 @@ class RSPTorch(RSP[Tensor], ABC):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def fft(
@@ -82,6 +84,8 @@ class AWR1843AOP(RSPTorch):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not specified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(
@@ -113,6 +117,8 @@ class AWR1843Boost(RSPTorch):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(
@@ -147,6 +153,8 @@ class AWR1642Boost(RSPTorch):
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
             If an axis is not spacified, it is not padded.
+        sample_swap: if `True`, swap the I and Q components when
+            un-interleaving IIQQ data.
     """
 
     def mimo_virtual_array(

--- a/src/xwr/rsp/torch/rsp.py
+++ b/src/xwr/rsp/torch/rsp.py
@@ -18,7 +18,7 @@ class RSPTorch(RSP[Tensor], ABC):
             is applied to all axes. If `dict`, specify per axis with keys
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
-            If an axis is not spacified, it is not padded.
+            If an axis is not specified, it is not padded.
         sample_swap: if `True`, swap the I and Q components when
             un-interleaving IIQQ data.
     """
@@ -116,7 +116,7 @@ class AWR1843Boost(RSPTorch):
             is applied to all axes. If `dict`, specify per axis with keys
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
-            If an axis is not spacified, it is not padded.
+            If an axis is not specified, it is not padded.
         sample_swap: if `True`, swap the I and Q components when
             un-interleaving IIQQ data.
     """
@@ -152,7 +152,7 @@ class AWR1642Boost(RSPTorch):
             is applied to all axes. If `dict`, specify per axis with keys
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
-            If an axis is not spacified, it is not padded.
+            If an axis is not specified, it is not padded.
         sample_swap: if `True`, swap the I and Q components when
             un-interleaving IIQQ data.
     """
@@ -246,7 +246,7 @@ class AWR2944EVM(RSPTorch):
             is applied to all axes. If `dict`, specify per axis with keys
             "range", "doppler", "azimuth", and "elevation".
         size: target size for each axis after zero-padding, specified by axis.
-            If an axis is not spacified, it is not padded.
+            If an axis is not specified, it is not padded.
     """
 
     SAMPLE_TYPE = "I"


### PR DESCRIPTION
Adds a `sample_swap` option to `iq_from_iiqq`, `iqiq_from_iiqq`, and `RSP` to allow processing data collected by other systems with `MSB_LSB_QI` set (#48).

This option is technically available for RSP subclasses for in-phase-only devices, but the documentation for this option is hidden.