### PR TITLE
jax: batched point cloud processing

### DIFF
--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -116,9 +116,10 @@ class PointCloud:
             ang: detect angle index for every range doppler bin, as
                 `(elevation, azimuth)` along the trailing axis.
         """
-        idxs = jax.vmap(jax.vmap(jax.vmap(self._argmax_aoa)))(cube)
-        ang = jnp.stack((idxs), axis=-1)
-        return ang
+        el, az = cube.shape[-2:]
+        flat = cube.reshape(*cube.shape[:-2], el * az)
+        idx = jnp.argmax(flat, axis=-1)
+        return jnp.stack((idx // az, idx % az), axis=-1)
 
     def __call__(
         self,

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Sequence
 
-import jax
 from jax import numpy as jnp
 from jaxtyping import Array, Bool, Float32, Int
 
@@ -17,8 +16,8 @@ class PointCloud:
     the angle
     ```
     angles = jnp.arcsin(
-        jnp.linspace(-jnp.pi, jnp.pi, bin_size)
-        / (2 * jnp.pi * antenna_spacing)
+        jnp.clip(jnp.linspace(-1.0, 1.0, bin_size) / (2 * antenna_spacing),
+                 -1.0, 1.0)
     )
     ```
     where the *corrected* antenna spacing is calculated by
@@ -59,8 +58,10 @@ class PointCloud:
         antenna_spacing: antenna spacing in terms of wavelength (default 0.5
             for a half-wavelength grid). Sets the sin-space to angle mapping;
             when the chirp center frequency differs from the antenna design
-            frequency, it must be corrected using the formula above. A wrong
-            value gives systematically wrong angles, not an error.
+            frequency, it must be corrected using the formula above. Must be
+            positive; a non-positive value raises `ValueError`, while a wrong
+            (but positive) value gives systematically wrong angles, not an
+            error.
     """
 
     def __init__(
@@ -76,23 +77,27 @@ class PointCloud:
         assert len(angle_fov) == 2 and len(angle_size) == 2, (
             "angle_fov and angle_size must be a sequence of length 2."
         )
+        if antenna_spacing <= 0:
+            raise ValueError("antenna_spacing must be > 0")
         self.el_fov = jnp.deg2rad(angle_fov[0])
         self.az_fov = jnp.deg2rad(angle_fov[1])
-        self.el_angles = jnp.arcsin(
-            jnp.linspace(-jnp.pi, jnp.pi, angle_size[0])
-            / (2 * jnp.pi * antenna_spacing)
-        )
-        self.az_angles = jnp.arcsin(
-            jnp.linspace(-jnp.pi, jnp.pi, angle_size[1])
-            / (2 * jnp.pi * antenna_spacing)
-        )
+        el_sin = jnp.clip(
+            jnp.linspace(-1.0, 1.0, angle_size[0]) / (2 * antenna_spacing),
+            -1.0, 1.0)
+        az_sin = jnp.clip(
+            jnp.linspace(-1.0, 1.0, angle_size[1]) / (2 * antenna_spacing),
+            -1.0, 1.0)
+        self.el_angles = jnp.arcsin(el_sin)
+        self.az_angles = jnp.arcsin(az_sin)
 
     @staticmethod
-    def _argmax_aoa(ang_sptr: Float32[Array, "el az"]) -> tuple[Array, ...]:
+    def _argmax_aoa(ang_sptr: Float32[Array, "... el az"]) -> Int[
+        Array, "... 2"
+    ]:
         """Get the (elevation, azimuth) index of the spectrum peak."""
-        idx = jnp.argmax(ang_sptr)
-        idx2d = jnp.unravel_index(idx, ang_sptr.shape)
-        return idx2d
+        el, az = ang_sptr.shape[-2:]
+        idx = jnp.argmax(ang_sptr.reshape(*ang_sptr.shape[:-2], el * az), -1)
+        return jnp.stack((idx // az, idx % az), axis=-1)
 
     def aoa(
         self, cube: Float32[Array, "batch range doppler el az"]
@@ -116,10 +121,7 @@ class PointCloud:
             ang: detect angle index for every range doppler bin, as
                 `(elevation, azimuth)` along the trailing axis.
         """
-        el, az = cube.shape[-2:]
-        flat = cube.reshape(*cube.shape[:-2], el * az)
-        idx = jnp.argmax(flat, axis=-1)
-        return jnp.stack((idx // az, idx % az), axis=-1)
+        return self._argmax_aoa(cube)
 
     def __call__(
         self,

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -6,6 +6,8 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import Array, Bool, Float32, Int
 
+from xwr.config import XWRConfig
+
 
 class PointCloud:
     """Get radar point cloud from post FFT cube.
@@ -32,98 +34,138 @@ class PointCloud:
         scale factor when the chirp center frequency differs.
 
     Args:
-        range_resolution: range fft resolution
-        doppler_resolution: doppler fft resolution
-        angle_fov: angle field of view in degrees for (elevation, azimuth).
-        angle_size: angle fft size for (elevation, azimuth).
-        antenna_spacing: antenna spacing in terms of wavelength (default 0.5).
+        config: radar configuration; see [`XWRConfig`][xwr.config.]. Only the
+            derived `range_resolution` (meters per range bin) and
+            `doppler_resolution` (meters/second per doppler bin) are used.
+
+            - Range bins are mapped to meters by `bin * range_resolution`, so
+              bin `0` is zero range.
+            - Doppler bins are mapped to *signed* radial velocity by
+              `(bin - doppler // 2) * doppler_resolution`, so the middle bin
+              is zero velocity. This assumes the doppler axis has already
+              been `fftshift`ed, which [`doppler_range`][xwr.rsp.RSP.] does.
+        angle_fov: angle field of view **in degrees** for (elevation,
+            azimuth), applied as a symmetric `±fov` bound. Points whose
+            estimated angle falls outside the bound are excluded from the
+            returned mask. This rejects estimates near the edge of the array's
+            sin-space, where a sparse MIMO array has little real resolving
+            power and grating lobes appear.
+        angle_size: angle fft size for (elevation, azimuth). **Must match the
+            `size={"elevation": ..., "azimuth": ...}` the
+            [`RSP`][xwr.rsp.] was constructed with**: the bin-to-angle lookup
+            tables are built at this length, then indexed by the argmax over
+            the cube's angle axes. A mismatch silently yields wrong angles
+            rather than an error.
+        antenna_spacing: antenna spacing in terms of wavelength (default 0.5
+            for a half-wavelength grid). Sets the sin-space to angle mapping;
+            when the chirp center frequency differs from the antenna design
+            frequency, it must be corrected using the formula above. A wrong
+            value gives systematically wrong angles, not an error.
     """
 
     def __init__(
         self,
-        range_resolution: float,
-        doppler_resolution: float,
+        config: XWRConfig,
         angle_fov: Sequence[float] = (20.0, 80.0),
         angle_size: Sequence[int] = (128, 128),
         antenna_spacing: float = 0.5,
     ) -> None:
-        self.range_res = range_resolution
-        self.doppler_res = doppler_resolution
+        self.range_res = config.range_resolution
+        self.doppler_res = config.doppler_resolution
 
         assert len(angle_fov) == 2 and len(angle_size) == 2, (
             "angle_fov and angle_size must be a sequence of length 2."
         )
-        self.ele_fov = jnp.deg2rad(angle_fov[0])
-        self.azi_fov = jnp.deg2rad(angle_fov[1])
-        self.ele_angles = jnp.arcsin(
+        self.el_fov = jnp.deg2rad(angle_fov[0])
+        self.az_fov = jnp.deg2rad(angle_fov[1])
+        self.el_angles = jnp.arcsin(
             jnp.linspace(-jnp.pi, jnp.pi, angle_size[0])
             / (2 * jnp.pi * antenna_spacing)
         )
-        self.azi_angles = jnp.arcsin(
+        self.az_angles = jnp.arcsin(
             jnp.linspace(-jnp.pi, jnp.pi, angle_size[1])
             / (2 * jnp.pi * antenna_spacing)
         )
 
     @staticmethod
-    def _argmax_aoa(ang_sptr: Float32[Array, "ele azi"]) -> tuple[Array, ...]:
-        """Argmax for angle of arrival estimation.
-
-        Args:
-            ang_sptr: post fft angle spectrum amplitude in 2D.
-
-        Returns:
-            detected angle index (elevation, azimuth).
-        """
+    def _argmax_aoa(ang_sptr: Float32[Array, "el az"]) -> tuple[Array, ...]:
+        """Get the (elevation, azimuth) index of the spectrum peak."""
         idx = jnp.argmax(ang_sptr)
         idx2d = jnp.unravel_index(idx, ang_sptr.shape)
         return idx2d
 
     def aoa(
-        self, cube: Float32[Array, "range doppler ele azi"]
-    ) -> Int[Array, "range doppler 2"]:
+        self, cube: Float32[Array, "batch range doppler el az"]
+    ) -> Int[Array, "batch range doppler 2"]:
         """Angle of arrival estimation.
 
+        Takes the argmax over the (elevation, azimuth) angle spectrum of each
+        range-doppler bin, yielding **bin indices** into the `el_angles` and
+        `az_angles` lookup tables rather than angles.
+
+        !!! warning
+
+            This assumes at most one scatterer per range-doppler cell; if two
+            targets share a range and velocity, only the stronger is reported.
+
         Args:
-            cube: post fft spectrum amplitude.
+            cube: batch of post fft spectrum amplitudes, with the angle axes
+                trailing.
 
         Returns:
-            ang: detect angle index for every range doppler bin.
+            ang: detect angle index for every range doppler bin, as
+                `(elevation, azimuth)` along the trailing axis.
         """
-        idxs = jax.vmap(jax.vmap(self._argmax_aoa))(cube)
+        idxs = jax.vmap(jax.vmap(jax.vmap(self._argmax_aoa)))(cube)
         ang = jnp.stack((idxs), axis=-1)
         return ang
 
     def __call__(
         self,
-        cube: Float32[Array, "doppler ele azi range"],
-        mask: Bool[Array, "range doppler"],
-    ) -> tuple[Bool[Array, "range doppler"], Float32[Array, "range doppler 4"]]:
+        cube: Float32[Array, "batch doppler el az range"],
+        mask: Bool[Array, "batch range doppler"],
+    ) -> tuple[
+        Bool[Array, "batch range doppler"],
+        Float32[Array, "batch range doppler 4"],
+    ]:
         """Get point cloud from radar cube and detection mask.
 
+        !!! note
+
+            The returned point cloud is **dense**: every range-doppler bin
+            yields a point, and the caller is expected to gather the valid
+            ones using the returned mask (e.g. `pc[pc_mask]`).
+
         Args:
-            cube: post fft spectrum amplitude.
+            cube: batch of post fft spectrum amplitudes.
             mask: CFAR detection mask.
 
         Returns:
-            mask of valid points (given the specified angular bounds)
-            all possible radar points
+            mask of valid points, i.e. the CFAR detection mask combined with
+                the angular bounds set by `angle_fov`.
+            all possible radar points, where the trailing axis holds
+                `(x, y, z, v)`: position in meters and signed radial velocity
+                in meters/second. Position is computed as
+                `x = r cos(-az) cos(el)`, `y = r sin(-az) cos(el)`, and
+                `z = r sin(el)`; note that the azimuth angle is **negated**,
+                and that `x` is the boresight direction at zero angle.
         """
-        r_size, d_size = mask.shape
+        _, r_size, d_size = mask.shape
         range_v = jnp.arange(r_size) * self.range_res
         doppler_v = (jnp.arange(d_size) - d_size // 2) * self.doppler_res
         r_grid, d_grid = jnp.meshgrid(range_v, doppler_v, indexing="ij")
 
-        angle_idx = self.aoa(cube.transpose(3, 0, 1, 2))
-        ang_e = self.ele_angles[angle_idx[:, :, 0]]
-        ang_a = self.azi_angles[angle_idx[:, :, 1]]
-        mask_e = jnp.logical_and(ang_e < self.ele_fov, ang_e > -self.ele_fov)
-        mask_a = jnp.logical_and(ang_a < self.azi_fov, ang_a > -self.azi_fov)
+        angle_idx = self.aoa(cube.transpose(0, 4, 1, 2, 3))
+        ang_e = self.el_angles[angle_idx[..., 0]]
+        ang_a = self.az_angles[angle_idx[..., 1]]
+        mask_e = jnp.logical_and(ang_e < self.el_fov, ang_e > -self.el_fov)
+        mask_a = jnp.logical_and(ang_a < self.az_fov, ang_a > -self.az_fov)
         mask_ang = jnp.logical_and(mask_a, mask_e)
 
         x = r_grid * jnp.cos(-ang_a) * jnp.cos(ang_e)
         y = r_grid * jnp.sin(-ang_a) * jnp.cos(ang_e)
         z = r_grid * jnp.sin(ang_e)
-        v = d_grid
+        v = jnp.broadcast_to(d_grid, x.shape)
 
         pc_mask = jnp.logical_and(mask, mask_ang)
         pc = jnp.stack((x, y, z, v), axis=-1)

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -40,7 +40,7 @@ class CFAR:
 
         ```python
         cfar = CFAR(guard=(2, 2), window=(4, 4))
-        thresholds = cfar(image)
+        thresholds = cfar(jnp.abs(range_doppler))
         mask = (thresholds > scipy.stats.norm.isf(0.01))
         ```
 
@@ -59,24 +59,10 @@ class CFAR:
         mask[w0 - g0 : w0 + g0 + 1, w1 - g1 : w1 + g1 + 1] = 0.0
         self.mask: Array = jnp.array(mask)
 
-    def __call__(self, x: Float[Array, "d r ..."]) -> Float[Array, "d r"]:
-        """Get CFAR thresholds.
-
-        !!! note
-
-            Boundary cells are zero-padded.
-
-        Args:
-            x: input. If more than 2 axes are present, the additional axes
-                are averaged before running CFAR.
-
-        Returns:
-            CFAR threshold values for this input.
-        """
-        # Collapse additional axes if required
-        if x.ndim > 2:
-            x = jnp.mean(x.reshape(x.shape[0], x.shape[1], -1), -1)
-
+    def _cfar(
+        self, x: Float[Array, "range doppler"]
+    ) -> Float[Array, "range doppler"]:
+        """Get CFAR scores for a single range-doppler image."""
         # Jax currently only supports 'fill', but this should be changed to
         # 'wrap' if they ever decide to add support.
         valid = convolve2d(jnp.ones_like(x), self.mask, mode="same")
@@ -86,12 +72,34 @@ class CFAR:
 
         return (x - mu) / sigma
 
+    def __call__(
+        self, signal_cube: Float[Array, "batch doppler tx rx range"]
+    ) -> Float[Array, "batch range doppler"]:
+        """Get CFAR scores.
+
+        Args:
+            signal_cube: batch of post range doppler FFT radar cubes in
+                amplitude.
+
+        Returns:
+            CFAR z-scores, i.e. the number of standard deviations each cell
+                lies above its local mean. This is not a threshold level and
+                not a boolean mask; see the note above on applying a
+                threshold.
+        """
+        b, d, _, _, r = signal_cube.shape
+        # Combine along the antenna array, and reorder to (range, doppler).
+        range_dopp = signal_cube.transpose(0, 4, 1, 2, 3).reshape(b, r, d, -1)
+        x = jnp.mean(range_dopp, axis=-1)
+
+        return jax.vmap(self._cfar)(x)
+
 
 class CFARCASO:
     """Cell-averaging Smallest of CFAR.
 
-    Expects a 2d input, with the `guard` and `window` sizes corresponding to
-    the respective input axes.
+    Expects a batch of range-doppler cubes, with the `train_window` and
+    `guard_window` sizes corresponding to the (range, doppler) axes.
 
     !!! info
 
@@ -112,10 +120,27 @@ class CFARCASO:
     ```
 
     Args:
-        train_window: training window size for (range, doppler).
-        guard_window: guard window size for (range, doppler).
-        snr_thresh: signal to noise ratio threshold for (range, doppler).
-        discard_range: range bins (close, far) to discard around DC.
+        train_window: number of training cells on **each** side of the cell
+            under test, for (range, doppler). Rather than averaging both
+            sides, CASO ("smallest of") takes the **minimum** of the two
+            one-sided means, so a strong target on one side cannot inflate
+            the noise floor and mask a weaker target on the other.
+        guard_window: number of guard cells on **each** side of the cell
+            under test, for (range, doppler); these sit between the cell
+            under test and the training cells and are excluded from the noise
+            estimate. They absorb target energy spread by FFT sidelobes and
+            windowing, which would otherwise raise the target's own noise
+            floor. The asymmetric default reflects that range leakage is
+            broad while doppler needs no guard.
+        snr_thresh: signal to noise ratio threshold for (range, doppler), as
+            a **linear power ratio** (not dB). A cell is detected on an axis
+            when its integrated power exceeds `snr_thresh * noise`, and a
+            detection is reported only where **both** axes fire. Raising it
+            gives fewer false alarms and a lower probability of detection.
+        discard_range: range bins (close, far) to discard around DC. The
+            closest bins are dominated by TX to RX leakage and DC, and the
+            furthest are past useful SNR; discarded bins are forced to
+            non-detect and assigned unit noise.
     """
 
     def __init__(
@@ -158,48 +183,27 @@ class CFARCASO:
 
     @staticmethod
     def _caso(
-        signal: Float32[Array, "n"],
-        ker_a: Float32[Array, "w"],
-        ker_b: Float32[Array, "w"],
+        signal: Float[Array, "n"],
+        ker_a: Float[Array, "w"],
+        ker_b: Float[Array, "w"],
         snr: float,
         pad: int,
-    ) -> tuple[Bool[Array, "m"], Float32[Array, "m"]]:
-        """1D CFAR CASO.
-
-        Args:
-            signal: 1D frequency spectrum.
-            ker_a: one side cfar kernel.
-            ker_b: one side cfar kernel.
-            snr: signal to noise ratio threshold.
-            pad: padding number of the input signal.
-
-        Returns:
-            detection mask.
-            noise level.
-        """
+    ) -> tuple[Bool[Array, "m"], Float[Array, "m"]]:
+        """Run 1D CFAR CASO, returning a detection mask and noise level."""
         cor_a = jnp.correlate(signal, ker_a, mode="valid")
         cor_b = jnp.correlate(signal, ker_b, mode="valid")
         noise = jnp.minimum(cor_a, cor_b)
         detect = signal[pad:-pad] > snr * noise
         return detect, noise
 
-    def __call__(
-        self, signal_cube: Float32[Array, "doppler Rx Tx range"]
+    def _cfar(
+        self, signal_cube: Float[Array, "doppler tx rx range"]
     ) -> tuple[
         Bool[Array, "range doppler"],
-        Float32[Array, "range doppler"],
-        Float32[Array, "range doppler"],
+        Float[Array, "range doppler"],
+        Float[Array, "range doppler"],
     ]:
-        """Run 2D CFAR CASO.
-
-        Args:
-            signal_cube: post range doppler FFT radar cube in amplitude.
-
-        Returns:
-            cfar detected object mask.
-            range doppler spectrum for detection.
-            signal to noise ratio.
-        """
+        """Run 2D CFAR CASO on a single radar cube."""
         signal_cube = signal_cube.transpose(3, 0, 1, 2)
         s_r, s_d, _, _ = signal_cube.shape
         range_dopp = signal_cube.reshape(s_r, s_d, -1)
@@ -240,6 +244,32 @@ class CFARCASO:
         obj_mask = jnp.logical_and(detect_r, detect_d)
 
         return obj_mask, signal, snr
+
+    def __call__(
+        self, signal_cube: Float[Array, "batch doppler tx rx range"]
+    ) -> tuple[
+        Bool[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+    ]:
+        """Run 2D CFAR CASO.
+
+        !!! note
+
+            The transmit and receive antenna axes are combined
+            non-coherently, so their relative order does not matter.
+
+        Args:
+            signal_cube: batch of post range doppler FFT radar cubes in
+                amplitude.
+
+        Returns:
+            cfar detected object mask.
+            non-coherently integrated power across the virtual array, i.e.
+                the range-doppler spectrum used for detection.
+            signal to noise ratio, as a linear power ratio.
+        """
+        return jax.vmap(self._cfar)(signal_cube)
 
 
 class CalibratedSpectrum(Generic[TRSP]):

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -90,32 +90,6 @@ class CFAR:
         valid = convolve2d(jnp.ones_like(signal), self.mask, mode="same")
         return convolve2d(signal, self.mask, mode="same") / valid
 
-    def _cfar(
-        self, signal_cube: Float[Array, "batch doppler tx rx range"]
-    ) -> tuple[
-        Bool[Array, "batch range doppler"],
-        Float[Array, "batch range doppler"],
-        Float[Array, "batch range doppler"],
-    ]:
-        """Run 2D cell-averaging CFAR on a batch of radar cubes."""
-        # non-coherent signal combination along the antenna array
-        signal = jnp.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
-        _, s_r, _ = signal.shape
-
-        noise_r = jax.vmap(self._noise)(signal)
-
-        near, far = self.discard_r[0], self.discard_r[1]
-        # 1 outside the discarded band, so the reported SNR there is the raw
-        # signal rather than a division by zero.
-        noise = jnp.ones_like(signal).at[:, near : s_r - far].set(
-            noise_r[:, near : s_r - far])
-
-        snr = signal / noise
-        obj_mask = jnp.zeros(signal.shape, dtype=bool).at[
-            :, near : s_r - far].set(snr[:, near : s_r - far] > self.snr_thresh)
-
-        return obj_mask, signal, snr
-
     def __call__(
         self, signal_cube: Float[Array, "batch doppler tx rx range"]
     ) -> tuple[
@@ -140,7 +114,23 @@ class CFAR:
                 the range-doppler spectrum used for detection.
             signal to noise ratio, as a linear power ratio.
         """
-        return self._cfar(signal_cube)
+        # non-coherent signal combination along the antenna array
+        signal = jnp.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
+        _, s_r, _ = signal.shape
+
+        noise_r = jax.vmap(self._noise)(signal)
+
+        near, far = self.discard_r[0], self.discard_r[1]
+        # 1 outside the discarded band, so the reported SNR there is the raw
+        # signal rather than a division by zero.
+        noise = jnp.ones_like(signal).at[:, near : s_r - far].set(
+            noise_r[:, near : s_r - far])
+
+        snr = signal / noise
+        obj_mask = jnp.zeros(signal.shape, dtype=bool).at[
+            :, near : s_r - far].set(snr[:, near : s_r - far] > self.snr_thresh)
+
+        return obj_mask, signal, snr
 
 
 class CFARCASO:
@@ -207,91 +197,57 @@ class CFARCASO:
                 f"Discard range {discard_range} must be length 2.")
         if len(snr_thresh) != 2:
             raise ValueError(f"SNR thresh {snr_thresh} must be length 2.")
+        if any(t < 1 for t in train_window):
+            raise ValueError(
+                f"Train window {train_window} must be >= 1 on each axis.")
 
         # discard detect object around DC
         self.discard_r = discard_range
         self.snr_r, self.snr_d = snr_thresh
 
+        self.train_r, self.train_d = train_window
         self.pad_r = train_window[0] + guard_window[0]
         self.pad_d = train_window[1] + guard_window[1]
 
-        # caso
-        def make_caso_kernels(train, pad):
-            ker = np.zeros((2 * pad + 1), dtype=np.float32)
-            ker_a, ker_b = ker.copy(), ker.copy()
-            ker_a[:train], ker_b[-train:] = 1, 1
-            ker_a /= ker_a.sum()
-            ker_b /= ker_b.sum()
-            return jnp.asarray(ker_a), jnp.asarray(ker_b)
-
-        self.r_ker_a, self.r_ker_b = make_caso_kernels(
-            train_window[0], self.pad_r)
-        self.d_ker_a, self.d_ker_b = make_caso_kernels(
-            train_window[1], self.pad_d)
-
     @staticmethod
     def _caso(
-        signal: Float[Array, "n"],
-        ker_a: Float[Array, "w"],
-        ker_b: Float[Array, "w"],
-        snr: float,
+        signal: Float[Array, "..."],
+        axis: int,
+        train: int,
         pad: int,
-    ) -> tuple[Bool[Array, "m"], Float[Array, "m"]]:
-        """Run 1D CFAR CASO, returning a detection mask and noise level."""
-        cor_a = jnp.correlate(signal, ker_a, mode="valid")
-        cor_b = jnp.correlate(signal, ker_b, mode="valid")
-        noise = jnp.minimum(cor_a, cor_b)
-        detect = signal[pad:-pad] > snr * noise
-        return detect, noise
+        snr: float,
+    ) -> tuple[Bool[Array, "..."], Float[Array, "..."]]:
+        """Run 1D CFAR CASO along `axis` of an arbitrarily batched array.
 
-    def _cfar(
-        self, signal_cube: Float[Array, "doppler tx rx range"]
-    ) -> tuple[
-        Bool[Array, "range doppler"],
-        Float[Array, "range doppler"],
-        Float[Array, "range doppler"],
-    ]:
-        """Run 2D CFAR CASO on a single radar cube."""
-        signal_cube = signal_cube.transpose(3, 0, 1, 2)
-        s_r, s_d, _, _ = signal_cube.shape
-        range_dopp = signal_cube.reshape(s_r, s_d, -1)
+        The training cells are a contiguous box on each side of the cell under
+        test, so the leading and trailing one-sided means are accumulated
+        directly from shifted slices rather than correlated against a mostly
+        zero kernel. `train` is a static Python int, so the sum unrolls at
+        trace time.
 
-        # non-coherent signal combination along the antenna array
-        signal = jnp.sum(range_dopp**2, axis=-1) + 1
-        sig_discard = signal[self.discard_r[0] : s_r - self.discard_r[1]]
-        sig_pad_r = jnp.concat(
-            (
-                sig_discard[: self.pad_r],
-                sig_discard,
-                sig_discard[-self.pad_r :],
-            ),
-            axis=0,
-        )
-        sig_pad_d = jnp.pad(
-            signal, ((0, 0), (self.pad_d, self.pad_d)), mode="wrap"
-        )
+        Args:
+            signal: signal, already padded by `pad` on both ends of `axis`.
+            axis: axis to run CFAR along.
+            train: number of training cells on each side.
+            pad: number of training plus guard cells on each side.
+            snr: signal to noise ratio threshold, as a linear power ratio.
 
-        # detection
-        detect_r, noise = jax.vmap(
-            self._caso, in_axes=(1, None, None, None, None)
-        )(sig_pad_r, self.r_ker_a, self.r_ker_b, self.snr_r, self.pad_r)
-        detect_r, noise = detect_r.swapaxes(0, 1), noise.swapaxes(0, 1)
-        detect_r = jnp.pad(
-            detect_r, ((self.discard_r[0], self.discard_r[1]), (0, 0))
-        )
-        noise = jnp.pad(
-            noise,
-            ((self.discard_r[0], self.discard_r[1]), (0, 0)),
-            constant_values=1,
-        )
-        detect_d, _ = jax.vmap(self._caso, in_axes=(0, None, None, None, None))(
-            sig_pad_d, self.d_ker_a, self.d_ker_b, self.snr_d, self.pad_d
-        )
+        Returns:
+            detection mask and noise level, with `axis` trimmed by `2 * pad`
+                back to the unpadded length.
+        """
+        size = signal.shape[axis] - 2 * pad
 
-        snr = signal / noise
-        obj_mask = jnp.logical_and(detect_r, detect_d)
+        def one_sided(start: int) -> Float[Array, "..."]:
+            acc = jax.lax.slice_in_dim(signal, start, start + size, axis=axis)
+            for i in range(1, train):
+                acc = acc + jax.lax.slice_in_dim(
+                    signal, start + i, start + i + size, axis=axis)
+            return acc / train
 
-        return obj_mask, signal, snr
+        noise = jnp.minimum(one_sided(0), one_sided(2 * pad + 1 - train))
+        cut = jax.lax.slice_in_dim(signal, pad, pad + size, axis=axis)
+        return cut > snr * noise, noise
 
     def __call__(
         self, signal_cube: Float[Array, "batch doppler tx rx range"]
@@ -317,7 +273,39 @@ class CFARCASO:
                 the range-doppler spectrum used for detection.
             signal to noise ratio, as a linear power ratio.
         """
-        return jax.vmap(self._cfar)(signal_cube)
+        # non-coherent signal combination along the antenna array
+        signal = jnp.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
+        _, s_r, _ = signal.shape
+
+        near, far = self.discard_r[0], self.discard_r[1]
+        sig_discard = signal[:, near : s_r - far]
+        sig_pad_r = jnp.concat(
+            (
+                sig_discard[:, : self.pad_r],
+                sig_discard,
+                sig_discard[:, -self.pad_r :],
+            ),
+            axis=1,
+        )
+        sig_pad_d = jnp.pad(
+            signal, ((0, 0), (0, 0), (self.pad_d, self.pad_d)), mode="wrap"
+        )
+
+        # detection
+        detect_r, noise_r = self._caso(
+            sig_pad_r, 1, self.train_r, self.pad_r, self.snr_r)
+        detect_r = jnp.pad(detect_r, ((0, 0), (near, far), (0, 0)))
+        # 1 outside the discarded band, so the reported SNR there is the raw
+        # signal rather than a division by zero.
+        noise = jnp.pad(
+            noise_r, ((0, 0), (near, far), (0, 0)), constant_values=1)
+        detect_d, _ = self._caso(
+            sig_pad_d, 2, self.train_d, self.pad_d, self.snr_d)
+
+        snr = signal / noise
+        obj_mask = jnp.logical_and(detect_r, detect_d)
+
+        return obj_mask, signal, snr
 
 
 class CalibratedSpectrum(Generic[TRSP]):

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -19,8 +19,8 @@ TRSP = TypeVar("TRSP", bound=RSPJax)
 class CFAR:
     """Cell-averaging CFAR.
 
-    Expects a 2d input, with the `guard` and `window` sizes corresponding to
-    the respective input axes.
+    Expects a batch of range-doppler cubes, with the `guard` and `window`
+    sizes corresponding to the (range, doppler) axes.
 
     ```
         ┌─────────────────┐ ▲ window[0]
@@ -32,67 +32,115 @@ class CFAR:
     guard[1] ◄──► ◄───────► window[1]
     ```
 
-    !!! note
+    !!! info
 
-        The user is responsible for applying the desired thresholding.
-        For example, when using a gaussian model, the threshold should be
-        calculated using an inverse normal CDF (e.g. `scipy.stats.norm.isf`):
-
-        ```python
-        cfar = CFAR(guard=(2, 2), window=(4, 4))
-        thresholds = cfar(jnp.abs(range_doppler))
-        mask = (thresholds > scipy.stats.norm.isf(0.01))
-        ```
+        The noise floor is the mean of the training cells in the 2D ring,
+        which tests the cell under test once; contrast
+        [`CFARCASO`][xwr.rsp.jax.CFARCASO], which tests the range and doppler
+        axes separately and requires **both** to fire.
 
     Args:
         guard: size of guard cells (excluded from noise estimation).
         window: total CFAR window size.
+        snr_thresh: signal to noise ratio threshold, as a **linear power
+            ratio** (not dB). A cell is detected when its integrated power
+            exceeds `snr_thresh * noise`. Raising it gives fewer false alarms
+            and a lower probability of detection.
+        discard_range: range bins (close, far) to discard around DC. The
+            closest bins are dominated by TX to RX leakage and DC, and the
+            furthest are past useful SNR; discarded bins are forced to
+            non-detect and assigned unit noise.
     """
 
     def __init__(
-        self, guard: tuple[int, int] = (2, 2), window: tuple[int, int] = (4, 4)
+        self,
+        guard: tuple[int, int] = (2, 2),
+        window: tuple[int, int] = (4, 4),
+        snr_thresh: float = 5.0,
+        discard_range: Sequence[int] = (10, 20),
     ) -> None:
+        if len(discard_range) != 2:
+            raise ValueError(
+                f"Discard range {discard_range} must be length 2.")
+
+        self.snr_thresh = snr_thresh
+        # discard detect object around DC
+        self.discard_r = discard_range
+
         w0, w1 = window
         g0, g1 = guard
+        if g0 > w0 or g1 > w1:
+            raise ValueError(
+                f"Guard {guard} must be <= window {window} on each axis.")
 
         mask = np.ones((2 * w0 + 1, 2 * w1 + 1), dtype=np.float32)
         mask[w0 - g0 : w0 + g0 + 1, w1 - g1 : w1 + g1 + 1] = 0.0
+        if mask.sum() == 0:
+            raise ValueError(
+                f"CFAR mask is empty; check guard={guard} and window={window}.")
         self.mask: Array = jnp.array(mask)
 
-    def _cfar(
-        self, x: Float[Array, "range doppler"]
+    def _noise(
+        self, signal: Float[Array, "range doppler"]
     ) -> Float[Array, "range doppler"]:
-        """Get CFAR scores for a single range-doppler image."""
+        """Get the ring-averaged noise floor for a range-doppler image."""
         # Jax currently only supports 'fill', but this should be changed to
-        # 'wrap' if they ever decide to add support.
-        valid = convolve2d(jnp.ones_like(x), self.mask, mode="same")
-        mu = convolve2d(x, self.mask, mode="same") / valid
-        second_moment = convolve2d(x**2, self.mask, mode="same") / valid
-        sigma = jnp.sqrt(second_moment - mu**2)
+        # 'wrap' if they ever decide to add support; the training cell count
+        # is normalized out to compensate at the edges.
+        valid = convolve2d(jnp.ones_like(signal), self.mask, mode="same")
+        return convolve2d(signal, self.mask, mode="same") / valid
 
-        return (x - mu) / sigma
+    def _cfar(
+        self, signal_cube: Float[Array, "batch doppler tx rx range"]
+    ) -> tuple[
+        Bool[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+    ]:
+        """Run 2D cell-averaging CFAR on a batch of radar cubes."""
+        # non-coherent signal combination along the antenna array
+        signal = jnp.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
+        _, s_r, _ = signal.shape
+
+        noise_r = jax.vmap(self._noise)(signal)
+
+        near, far = self.discard_r[0], self.discard_r[1]
+        # 1 outside the discarded band, so the reported SNR there is the raw
+        # signal rather than a division by zero.
+        noise = jnp.ones_like(signal).at[:, near : s_r - far].set(
+            noise_r[:, near : s_r - far])
+
+        snr = signal / noise
+        obj_mask = jnp.zeros(signal.shape, dtype=bool).at[
+            :, near : s_r - far].set(snr[:, near : s_r - far] > self.snr_thresh)
+
+        return obj_mask, signal, snr
 
     def __call__(
         self, signal_cube: Float[Array, "batch doppler tx rx range"]
-    ) -> Float[Array, "batch range doppler"]:
-        """Get CFAR scores.
+    ) -> tuple[
+        Bool[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+    ]:
+        """Run 2D cell-averaging CFAR.
+
+        !!! note
+
+            The transmit and receive antenna axes are combined
+            non-coherently, so their relative order does not matter.
 
         Args:
             signal_cube: batch of post range doppler FFT radar cubes in
                 amplitude.
 
         Returns:
-            CFAR z-scores, i.e. the number of standard deviations each cell
-                lies above its local mean. This is not a threshold level and
-                not a boolean mask; see the note above on applying a
-                threshold.
+            cfar detected object mask.
+            non-coherently integrated power across the virtual array, i.e.
+                the range-doppler spectrum used for detection.
+            signal to noise ratio, as a linear power ratio.
         """
-        b, d, _, _, r = signal_cube.shape
-        # Combine along the antenna array, and reorder to (range, doppler).
-        range_dopp = signal_cube.transpose(0, 4, 1, 2, 3).reshape(b, r, d, -1)
-        x = jnp.mean(range_dopp, axis=-1)
-
-        return jax.vmap(self._cfar)(x)
+        return self._cfar(signal_cube)
 
 
 class CFARCASO:
@@ -210,7 +258,7 @@ class CFARCASO:
 
         # non-coherent signal combination along the antenna array
         signal = jnp.sum(range_dopp**2, axis=-1) + 1
-        sig_discard = signal[self.discard_r[0] : -self.discard_r[1]]
+        sig_discard = signal[self.discard_r[0] : s_r - self.discard_r[1]]
         sig_pad_r = jnp.concat(
             (
                 sig_discard[: self.pad_r],


### PR DESCRIPTION
- Fix #29: unify all point cloud processing interfaces to process batched input.

Part of a stack (see #58): **#55 (this PR)** → #56 (torch backend) → #57 (tests).