### PR TITLE
tests: CFAR and AoA backend tests

### DIFF
--- a/tests/test_aoa.py
+++ b/tests/test_aoa.py
@@ -1,0 +1,269 @@
+"""Angle of arrival / point cloud geometry tests."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+
+from xwr.config import XWRConfig
+from xwr.radar import AWR1843
+from xwr.rsp import jax as rspj
+from xwr.rsp import torch as rspt
+
+BACKENDS = ["jax", "torch"]
+
+# Odd angle sizes, so `linspace(-1, 1, n)` has an exact 0 at the center bin
+# and boresight is exactly representable.
+EL, AZ = 9, 9
+CENTER = 4
+BATCH, DOPPLER, RANGE = 1, 4, 5
+
+
+@pytest.fixture
+def config():
+    """A valid AWR1843 configuration."""
+    return XWRConfig(
+        device=AWR1843,
+        frequency=77.0,
+        idle_time=200.0,
+        adc_start_time=5.7,
+        ramp_end_time=59.0,
+        tx_start_time=1.0,
+        freq_slope=67.012,
+        adc_samples=128,
+        sample_rate=2500,
+        frame_length=128,
+        frame_period=125.0,
+    )
+
+
+def _peak_cube(el: int, az: int) -> np.ndarray:
+    """Cube whose angle spectrum peaks at `(el, az)` for every bin."""
+    cube = np.zeros((BATCH, DOPPLER, EL, AZ, RANGE), dtype=np.float32)
+    cube[:, :, el, az, :] = 1.0
+    return cube
+
+
+def _point_cloud(backend, config, cube, mask=None, **kwargs):
+    """Run `PointCloud` in the given backend, returning numpy arrays."""
+    if mask is None:
+        mask = np.ones((BATCH, RANGE, DOPPLER), dtype=bool)
+
+    kwargs.setdefault("angle_size", (EL, AZ))
+    if backend == "jax":
+        pc = rspj.PointCloud(config, **kwargs)
+        pc_mask, points = pc(jnp.array(cube), jnp.array(mask))
+        return np.asarray(pc_mask), np.asarray(points)
+
+    pc = rspt.PointCloud(config, **kwargs)
+    pc_mask, points = pc(torch.from_numpy(cube), torch.from_numpy(mask))
+    return pc_mask.numpy(), points.numpy()
+
+
+def _angles(backend, config, **kwargs):
+    """Get the (elevation, azimuth) lookup tables as numpy arrays."""
+    kwargs.setdefault("angle_size", (EL, AZ))
+    if backend == "jax":
+        pc = rspj.PointCloud(config, **kwargs)
+        return np.asarray(pc.el_angles), np.asarray(pc.az_angles)
+
+    pc = rspt.PointCloud(config, **kwargs)
+    return pc.el_angles.numpy(), pc.az_angles.numpy()
+
+
+# ---------------------------------------------------------------------------
+# Geometry conventions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_boresight(backend, config):
+    """A boresight peak lies on the +x axis: y and z are both zero."""
+    _, points = _point_cloud(
+        backend, config, _peak_cube(CENTER, CENTER),
+        angle_fov=(90.0, 90.0))
+
+    x, y, z, _ = np.moveaxis(points, -1, 0)
+    assert np.allclose(y, 0.0, atol=1e-6)
+    assert np.allclose(z, 0.0, atol=1e-6)
+    # x is the range itself, broadcast over doppler.
+    expected = np.arange(RANGE) * config.range_resolution
+    assert np.allclose(x[0], expected[:, None], atol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_azimuth_is_negated(backend, config):
+    """A positive azimuth bin maps to negative y; the angle is negated."""
+    el_angles, az_angles = _angles(backend, config, angle_fov=(90.0, 90.0))
+    assert az_angles[CENTER + 2] > 0
+
+    _, points = _point_cloud(
+        backend, config, _peak_cube(CENTER, CENTER + 2),
+        angle_fov=(90.0, 90.0))
+
+    x, y, z, _ = np.moveaxis(points, -1, 0)
+    # Nonzero range bins only; bin 0 sits at the origin.
+    assert (y[0, 1:] < 0).all()
+    assert (x[0, 1:] > 0).all()
+    assert np.allclose(z, 0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_elevation_is_positive_z(backend, config):
+    """A positive elevation bin maps to positive z."""
+    _, points = _point_cloud(
+        backend, config, _peak_cube(CENTER + 2, CENTER),
+        angle_fov=(90.0, 90.0))
+
+    x, y, z, _ = np.moveaxis(points, -1, 0)
+    assert (z[0, 1:] > 0).all()
+    assert (x[0, 1:] > 0).all()
+    assert np.allclose(y, 0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("el,az", [(CENTER, CENTER), (CENTER, CENTER + 2),
+                                   (CENTER + 2, CENTER), (CENTER - 3, 1)])
+def test_range_and_velocity(backend, config, el, az):
+    """Position norm is the range, and the last channel is signed velocity."""
+    _, points = _point_cloud(
+        backend, config, _peak_cube(el, az), angle_fov=(90.0, 90.0))
+
+    x, y, z, v = np.moveaxis(points, -1, 0)
+
+    expected_range = np.arange(RANGE) * config.range_resolution
+    assert np.allclose(
+        np.sqrt(x**2 + y**2 + z**2)[0], expected_range[:, None], atol=1e-6)
+
+    expected_v = (
+        np.arange(DOPPLER) - DOPPLER // 2) * config.doppler_resolution
+    assert np.allclose(v[0], expected_v[None, :], atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Masking
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_angle_fov(backend, config):
+    """Peaks outside the field of view are excluded from the mask."""
+    fov = {"angle_fov": (5.0, 5.0)}
+
+    kept, _ = _point_cloud(backend, config, _peak_cube(CENTER, CENTER), **fov)
+    assert kept.all()
+
+    for cube in (_peak_cube(CENTER, CENTER + 2),
+                 _peak_cube(CENTER + 2, CENTER)):
+        rejected, _ = _point_cloud(backend, config, cube, **fov)
+        assert not rejected.any()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_detection_mask_is_combined(backend, config):
+    """The output mask is the detection mask AND the angular bounds."""
+    rng = np.random.default_rng(0)
+    mask = rng.random((BATCH, RANGE, DOPPLER)) > 0.5
+
+    # In-bounds angle: the detection mask passes through unchanged.
+    kept, _ = _point_cloud(
+        backend, config, _peak_cube(CENTER, CENTER), mask=mask,
+        angle_fov=(90.0, 90.0))
+    assert np.array_equal(kept, mask)
+
+    # Out-of-bounds angle: nothing survives, whatever the detection mask.
+    rejected, _ = _point_cloud(
+        backend, config, _peak_cube(CENTER, CENTER + 2), mask=mask,
+        angle_fov=(5.0, 5.0))
+    assert not rejected.any()
+
+
+# ---------------------------------------------------------------------------
+# Antenna spacing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("spacing", [0.5, 0.4, 0.25])
+def test_antenna_spacing_is_clamped(backend, config, spacing):
+    """Sub-half-wavelength spacing clamps to ±90° instead of yielding nan."""
+    el_angles, az_angles = _angles(
+        backend, config, antenna_spacing=spacing)
+
+    for angles in (el_angles, az_angles):
+        assert not np.isnan(angles).any()
+        assert np.isclose(angles[0], -np.pi / 2)
+        assert np.isclose(angles[-1], np.pi / 2)
+        # Still monotonic, so bin order is preserved.
+        assert (np.diff(angles) >= 0).all()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_antenna_spacing_must_be_positive(backend, config):
+    """A non-positive antenna spacing is rejected at construction."""
+    module = {"jax": rspj, "torch": rspt}[backend]
+    for spacing in (0.0, -0.5):
+        with pytest.raises(ValueError):
+            module.PointCloud(config, antenna_spacing=spacing)
+
+
+# ---------------------------------------------------------------------------
+# Cross-backend parity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spacing", [0.5, 0.4])
+def test_angle_table_parity(config, spacing):
+    """Both backends build identical bin-to-angle lookup tables."""
+    el_j, az_j = _angles("jax", config, antenna_spacing=spacing)
+    el_t, az_t = _angles("torch", config, antenna_spacing=spacing)
+
+    assert np.allclose(el_j, el_t, atol=1e-6)
+    assert np.allclose(az_j, az_t, atol=1e-6)
+
+
+def test_point_cloud_parity(config):
+    """Both backends produce the same point cloud from the same cube."""
+    rng = np.random.default_rng(0)
+    cube = rng.random(
+        (BATCH, DOPPLER, EL, AZ, RANGE)).astype(np.float32)
+    mask = rng.random((BATCH, RANGE, DOPPLER)) > 0.5
+
+    mask_j, points_j = _point_cloud("jax", config, cube, mask=mask)
+    mask_t, points_t = _point_cloud("torch", config, cube, mask=mask)
+
+    assert np.array_equal(mask_j, mask_t)
+    assert np.allclose(points_j, points_t, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# End to end
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("detector", ["CFAR", "CFARCASO"])
+def test_end_to_end_parity(config, detector):
+    """RSP -> detector -> point cloud agrees across backends."""
+    rng = np.random.default_rng(1)
+    shape = (2, 16, 3, 4, 32)
+    iq = (rng.random(shape) + 1j * rng.random(shape)).astype(np.complex64)
+
+    kwargs = (
+        {"guard": (2, 2), "window": (4, 4), "snr_thresh": 1.2,
+         "discard_range": (2, 2)}
+        if detector == "CFAR" else
+        {"train_window": (4, 2), "guard_window": (2, 0),
+         "snr_thresh": (1.2, 1.1), "discard_range": (2, 2)})
+
+    cube_j = jnp.abs(rspj.AWR1843Boost(window=False, size={})(jnp.array(iq)))
+    cube_t = torch.abs(
+        rspt.AWR1843Boost(window=False, size={})(torch.from_numpy(iq)))
+    _, _, el, az, _ = cube_j.shape
+
+    mask_j, _, _ = getattr(rspj, detector)(**kwargs)(cube_j)
+    mask_t, _, _ = getattr(rspt, detector)(**kwargs)(cube_t)
+    assert np.array_equal(np.asarray(mask_j), mask_t.numpy())
+    assert np.asarray(mask_j).any(), "no detections; test would be vacuous"
+
+    pc_mask_j, points_j = rspj.PointCloud(
+        config, angle_size=(el, az))(cube_j, mask_j)
+    pc_mask_t, points_t = rspt.PointCloud(
+        config, angle_size=(el, az))(cube_t, mask_t)
+
+    assert np.array_equal(np.asarray(pc_mask_j), pc_mask_t.numpy())
+    assert np.allclose(np.asarray(points_j), points_t.numpy(), atol=1e-4)

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -1,0 +1,251 @@
+"""Detector (CFAR / CFAR CASO) tests."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+
+from xwr.rsp import jax as rspj
+from xwr.rsp import torch as rspt
+
+# (batch, doppler, tx, rx, range) of the synthetic cubes used here.
+SHAPE = (1, 16, 3, 4, 64)
+TARGET = (30, 5)
+"""Injected target, as a (range, doppler) bin index."""
+
+
+def _target_cube(amplitude: float = 50.0, seed: int = 0) -> np.ndarray:
+    """Low-amplitude noise floor with a single strong target."""
+    rng = np.random.default_rng(seed)
+    cube = rng.random(SHAPE).astype(np.float32) * 0.1 + 0.1
+    cube[:, TARGET[1], :, :, TARGET[0]] = amplitude
+    return cube
+
+
+def _signal(cube: np.ndarray) -> np.ndarray:
+    """Reference non-coherent integration: (batch, range, doppler)."""
+    return (cube.astype(np.float64) ** 2).sum(axis=(2, 3)).transpose(0, 2, 1) + 1
+
+
+def _ring_noise(signal: np.ndarray, guard, window) -> np.ndarray:
+    """Reference ring-averaged noise floor, by explicit summation.
+
+    Zero-padded at the edges and normalized by the number of in-bounds
+    training cells, matching both backends' `valid` normalization.
+    """
+    (g0, g1), (w0, w1) = guard, window
+    mask = np.ones((2 * w0 + 1, 2 * w1 + 1))
+    mask[w0 - g0: w0 + g0 + 1, w1 - g1: w1 + g1 + 1] = 0.0
+
+    s_r, s_d = signal.shape
+    noise = np.zeros_like(signal)
+    for i in range(s_r):
+        for j in range(s_d):
+            total, count = 0.0, 0.0
+            for di in range(-w0, w0 + 1):
+                for dj in range(-w1, w1 + 1):
+                    if mask[di + w0, dj + w1] == 0:
+                        continue
+                    if 0 <= i + di < s_r and 0 <= j + dj < s_d:
+                        total += signal[i + di, j + dj]
+                        count += 1
+            noise[i, j] = total / count
+    return noise
+
+
+def _numpy(*arrays):
+    """Convert jax arrays or torch tensors to numpy."""
+    return tuple(
+        x.numpy() if isinstance(x, torch.Tensor) else np.asarray(x)
+        for x in arrays)
+
+
+def _run(backend, detector, cube: np.ndarray, **kwargs):
+    """Run a detector on `cube` in the given backend, returning numpy."""
+    module = {"jax": rspj, "torch": rspt}[backend]
+    data = jnp.array(cube) if backend == "jax" else torch.from_numpy(cube)
+    return _numpy(*getattr(module, detector)(**kwargs)(data))
+
+
+BACKENDS = ["jax", "torch"]
+
+CFAR_PARAMS = [
+    {"guard": (2, 2), "window": (4, 4), "snr_thresh": 5.0,
+     "discard_range": (10, 20)},
+    {"guard": (1, 1), "window": (3, 2), "snr_thresh": 2.0,
+     "discard_range": (4, 6)},
+    # far=0: `signal[near:-far]` would slice to empty; regression for the
+    # jax/torch divergence.
+    {"guard": (2, 2), "window": (4, 4), "snr_thresh": 5.0,
+     "discard_range": (4, 0)},
+    {"guard": (0, 0), "window": (2, 2), "snr_thresh": 3.0,
+     "discard_range": (0, 0)},
+]
+
+CASO_PARAMS = [
+    {"train_window": (8, 4), "guard_window": (8, 0), "snr_thresh": (5.0, 3.0),
+     "discard_range": (10, 20)},
+    {"train_window": (4, 2), "guard_window": (2, 0), "snr_thresh": (2.0, 1.5),
+     "discard_range": (4, 6)},
+    {"train_window": (4, 2), "guard_window": (2, 0), "snr_thresh": (5.0, 3.0),
+     "discard_range": (4, 0)},
+    {"train_window": (4, 2), "guard_window": (2, 0), "snr_thresh": (5.0, 3.0),
+     "discard_range": (0, 0)},
+]
+
+
+# ---------------------------------------------------------------------------
+# Cross-backend parity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kwargs", CFAR_PARAMS)
+def test_cfar_parity(kwargs):
+    """Jax and torch CFAR must agree; they mirror the same algorithm."""
+    cube = _target_cube()
+    mask_j, signal_j, snr_j = _run("jax", "CFAR", cube, **kwargs)
+    mask_t, signal_t, snr_t = _run("torch", "CFAR", cube, **kwargs)
+
+    assert np.array_equal(mask_j, mask_t)
+    assert np.allclose(signal_j, signal_t, atol=1e-4)
+    assert np.allclose(snr_j, snr_t, rtol=1e-4)
+
+
+@pytest.mark.parametrize("kwargs", CASO_PARAMS)
+def test_caso_parity(kwargs):
+    """Jax and torch CFAR CASO must agree."""
+    cube = _target_cube()
+    mask_j, signal_j, snr_j = _run("jax", "CFARCASO", cube, **kwargs)
+    mask_t, signal_t, snr_t = _run("torch", "CFARCASO", cube, **kwargs)
+
+    assert np.array_equal(mask_j, mask_t)
+    assert np.allclose(signal_j, signal_t, atol=1e-4)
+    assert np.allclose(snr_j, snr_t, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Detection correctness
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("detector", ["CFAR", "CFARCASO"])
+def test_detects_only_the_target(backend, detector):
+    """An isolated strong target is the one and only detection."""
+    cube = _target_cube()
+    kwargs = (
+        {"guard": (2, 2), "window": (4, 4), "snr_thresh": 5.0,
+         "discard_range": (10, 20)}
+        if detector == "CFAR" else
+        {"train_window": (4, 2), "guard_window": (2, 0),
+         "snr_thresh": (5.0, 3.0), "discard_range": (10, 20)})
+
+    mask, _, snr = _run(backend, detector, cube, **kwargs)
+
+    assert mask[0, TARGET[0], TARGET[1]]
+    # One detection per batch element, and nowhere else.
+    assert np.array_equal(
+        np.argwhere(mask), [[0, TARGET[0], TARGET[1]]])
+    assert snr[0, TARGET[0], TARGET[1]] > 5.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("detector", ["CFAR", "CFARCASO"])
+def test_integrated_signal(backend, detector):
+    """`signal` is the non-coherent sum over the virtual array, plus one."""
+    cube = _target_cube()
+    kwargs = (
+        {"discard_range": (10, 20)} if detector == "CFAR" else
+        {"train_window": (4, 2), "guard_window": (2, 0),
+         "discard_range": (10, 20)})
+
+    _, signal, _ = _run(backend, detector, cube, **kwargs)
+
+    assert signal.shape == (SHAPE[0], SHAPE[4], SHAPE[1])
+    assert np.allclose(signal, _signal(cube), rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("detector", ["CFAR", "CFARCASO"])
+def test_discard_band(backend, detector):
+    """Discarded range bins never detect, and are assigned unit noise."""
+    near, far = 10, 20
+    cube = _target_cube()
+    # Put a second target inside the discarded band; it must not fire.
+    cube[:, TARGET[1], :, :, near - 1] = 50.0
+    kwargs = (
+        {"discard_range": (near, far)} if detector == "CFAR" else
+        {"train_window": (4, 2), "guard_window": (2, 0),
+         "discard_range": (near, far)})
+
+    mask, signal, snr = _run(backend, detector, cube, **kwargs)
+    s_r = signal.shape[1]
+
+    assert not mask[:, :near].any()
+    assert not mask[:, s_r - far:].any()
+    # noise == 1 outside the band, so snr is the raw integrated signal.
+    assert np.allclose(snr[:, :near], signal[:, :near], rtol=1e-5)
+    assert np.allclose(snr[:, s_r - far:], signal[:, s_r - far:], rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_cfar_noise_floor(backend):
+    """The CFAR ring noise floor matches an explicit numpy reference."""
+    guard, window = (1, 1), (2, 2)
+    cube = _target_cube()
+    # No discarded band, so every bin exercises the ring average.
+    _, signal, snr = _run(
+        backend, "CFAR", cube, guard=guard, window=window,
+        discard_range=(0, 0))
+
+    expected = _ring_noise(_signal(cube)[0], guard, window)
+    assert np.allclose(signal[0] / snr[0], expected, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("kwargs", [
+    {"guard": (4, 4), "window": (2, 2)},        # guard exceeds window
+    {"guard": (2, 2), "window": (2, 2)},        # no training cells left
+    {"discard_range": (1, 2, 3)},               # wrong length
+])
+def test_cfar_invalid(backend, kwargs):
+    """Bad CFAR parameters are rejected at construction."""
+    module = {"jax": rspj, "torch": rspt}[backend]
+    with pytest.raises(ValueError):
+        module.CFAR(**kwargs)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("kwargs", [
+    {"train_window": (8, 4, 2)},
+    {"guard_window": (8, 0, 1)},
+    {"discard_range": (1, 2, 3)},
+    {"snr_thresh": (5.0, 3.0, 1.0)},
+])
+def test_caso_invalid(backend, kwargs):
+    """Bad CFAR CASO parameters are rejected at construction."""
+    module = {"jax": rspj, "torch": rspt}[backend]
+    with pytest.raises(ValueError):
+        module.CFARCASO(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Autodiff
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("detector,kwargs", [
+    ("CFAR", {"discard_range": (10, 20)}),
+    ("CFARCASO", {"train_window": (4, 2), "guard_window": (2, 0),
+                  "discard_range": (10, 20)}),
+])
+def test_torch_backward(detector, kwargs):
+    """Test that gradients flow through the torch detectors."""
+    cube = torch.from_numpy(_target_cube()).requires_grad_(True)
+
+    _, signal, snr = getattr(rspt, detector)(**kwargs)(cube)
+    (signal.sum() + snr.sum()).backward()
+
+    assert cube.grad is not None
+    assert cube.grad.shape == cube.shape


### PR DESCRIPTION
- Adds tests/test_aoa.py and tests/test_spectrum.py covering both the jax (#55) and torch (#56) backends.
- Addresses reviewer request for unit tests.

Part of a stack (see #58): #55 (jax) → #56 (torch) → **#57 (this PR)**.