### PR TITLE
abstract CFAR, CFARCASO, and PointCloud base classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Rerun recordings
+*.rrd

--- a/src/xwr/rsp/__init__.py
+++ b/src/xwr/rsp/__init__.py
@@ -47,9 +47,12 @@ To use the RSP:
 from jaxtyping import install_import_hook
 
 with install_import_hook("xwr.rsp", "beartype.beartype"):
-    from .generic import RSP, iq_from_iiqq, iqiq_from_iiqq
+    from .generic import RSP, iq_from_iiqq, iqiq_from_iiqq  # noqa: I001
+    from .aoa import PointCloud
+    from .spectrum import CFAR, CFARCASO, Detector
 
 
 __all__ = [
-    "RSP", "iq_from_iiqq", "iqiq_from_iiqq"
+    "RSP", "iq_from_iiqq", "iqiq_from_iiqq",
+    "Detector", "CFAR", "CFARCASO", "PointCloud"
 ]

--- a/src/xwr/rsp/__init__.py
+++ b/src/xwr/rsp/__init__.py
@@ -50,15 +50,16 @@ with install_import_hook("xwr.rsp", "beartype.beartype"):
     from .aoa import DensePoints, PointCloud
     from .generic import RSP, iq_from_iiqq, iqiq_from_iiqq
     from .spectrum import (
+        CACFAR,
+        CASOCFAR,
         CFAR,
-        CFARCASO,
         Detection,
-        Detector,
         SignalCube,
     )
 
 
 __all__ = [
     "RSP", "iq_from_iiqq", "iqiq_from_iiqq",
-    "Detector", "Detection", "SignalCube", "CFAR", "CFARCASO", "PointCloud", "DensePoints"
+    "CACFAR", "CASOCFAR", "CFAR", "Detection", "SignalCube",
+    "CFAR", "CASOCFAR", "PointCloud", "DensePoints"
 ]

--- a/src/xwr/rsp/__init__.py
+++ b/src/xwr/rsp/__init__.py
@@ -47,8 +47,8 @@ To use the RSP:
 from jaxtyping import install_import_hook
 
 with install_import_hook("xwr.rsp", "beartype.beartype"):
-    from .generic import RSP, iq_from_iiqq, iqiq_from_iiqq  # noqa: I001
     from .aoa import PointCloud
+    from .generic import RSP, iq_from_iiqq, iqiq_from_iiqq
     from .spectrum import CFAR, CFARCASO, Detector
 
 

--- a/src/xwr/rsp/__init__.py
+++ b/src/xwr/rsp/__init__.py
@@ -47,12 +47,18 @@ To use the RSP:
 from jaxtyping import install_import_hook
 
 with install_import_hook("xwr.rsp", "beartype.beartype"):
-    from .aoa import PointCloud
+    from .aoa import DensePoints, PointCloud
     from .generic import RSP, iq_from_iiqq, iqiq_from_iiqq
-    from .spectrum import CFAR, CFARCASO, Detector
+    from .spectrum import (
+        CFAR,
+        CFARCASO,
+        Detection,
+        Detector,
+        SignalCube,
+    )
 
 
 __all__ = [
     "RSP", "iq_from_iiqq", "iqiq_from_iiqq",
-    "Detector", "CFAR", "CFARCASO", "PointCloud"
+    "Detector", "Detection", "SignalCube", "CFAR", "CFARCASO", "PointCloud", "DensePoints"
 ]

--- a/src/xwr/rsp/__init__.py
+++ b/src/xwr/rsp/__init__.py
@@ -61,5 +61,5 @@ with install_import_hook("xwr.rsp", "beartype.beartype"):
 __all__ = [
     "RSP", "iq_from_iiqq", "iqiq_from_iiqq",
     "CACFAR", "CASOCFAR", "CFAR", "Detection", "SignalCube",
-    "CFAR", "CASOCFAR", "PointCloud", "DensePoints"
+    "PointCloud", "DensePoints"
 ]

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -83,7 +83,7 @@ class PointCloud(ABC, Generic[TArray]):
         self.el_fov = float(np.deg2rad(angle_fov[0]))
         self.az_fov = float(np.deg2rad(angle_fov[1]))
 
-    def angle_table(self, n: int) -> Float32[np.ndarray, " n"]:
+    def _angle_table(self, n: int) -> Float32[np.ndarray, " n"]:
         """Bin-to-angle lookup for an angle axis of length `n`.
 
         Args:
@@ -103,8 +103,8 @@ class PointCloud(ABC, Generic[TArray]):
         """Angle of arrival estimation.
 
         Takes the argmax over the (elevation, azimuth) angle spectrum of each
-        range-doppler bin, yielding **bin indices** into the
-        [`angle_table`][xwr.rsp.PointCloud.] lookups rather than angles.
+        range-doppler bin, yielding **bin indices** into the angle axes
+        rather than angles.
 
         !!! warning
 

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -47,11 +47,9 @@ class PointCloud(ABC, Generic[TArray]):
     positive; a non-positive value raises `ValueError`, while a wrong (but
     positive) value gives systematically wrong angles rather than an error.
 
-    `angle_size` **must match the `size={"elevation": ..., "azimuth": ...}`
-    the [`RSP`][xwr.rsp.] was constructed with**: the bin-to-angle lookup
-    tables are built at this length, then indexed by the argmax over the
-    cube's angle axes. A mismatch raises a `ValueError` when
-    [`__call__`][xwr.rsp.PointCloud.__call__] is invoked.
+    The bin-to-angle lookup tables are derived from the cube's own angle axes
+    on each call, so no angle size has to be declared up front and one
+    instance handles cubes of differing angle sizes.
 
     `angle_fov` is applied as a symmetric `±fov` bound, and points falling
     outside it are excluded from the returned mask. This rejects estimates
@@ -66,7 +64,6 @@ class PointCloud(ABC, Generic[TArray]):
         config: radar configuration; see [`XWRConfig`][xwr.config.].
         angle_fov: angle field of view **in degrees**, for
             (elevation, azimuth).
-        angle_size: angle fft size for (elevation, azimuth).
         antenna_spacing: antenna spacing in terms of wavelength (default 0.5
             for a half-wavelength grid).
     """
@@ -75,7 +72,6 @@ class PointCloud(ABC, Generic[TArray]):
         self,
         config: XWRConfig,
         angle_fov: tuple[float, float] = (20.0, 80.0),
-        angle_size: tuple[int, int] = (128, 128),
         antenna_spacing: float = 0.5,
     ) -> None:
         self.range_res = config.range_resolution
@@ -83,26 +79,33 @@ class PointCloud(ABC, Generic[TArray]):
 
         if antenna_spacing <= 0:
             raise ValueError("antenna_spacing must be > 0")
+        self.antenna_spacing = antenna_spacing
         self.el_fov = float(np.deg2rad(angle_fov[0]))
         self.az_fov = float(np.deg2rad(angle_fov[1]))
-        el_sin = np.clip(
-            np.linspace(-1.0, 1.0, angle_size[0]) / (2 * antenna_spacing),
-            -1.0, 1.0)
-        az_sin = np.clip(
-            np.linspace(-1.0, 1.0, angle_size[1]) / (2 * antenna_spacing),
-            -1.0, 1.0)
-        self.el_angles: Float[TArray, " el"] = self._asarray(
-            np.arcsin(el_sin).astype(np.float32))
-        self.az_angles: Float[TArray, " az"] = self._asarray(
-            np.arcsin(az_sin).astype(np.float32))
 
-    @staticmethod
+    def angle_table(self, n: int) -> Float32[np.ndarray, " n"]:
+        """Bin-to-angle lookup for an angle axis of length `n`.
+
+        Args:
+            n: length of the angle axis, i.e. the angle fft size.
+
+        Returns:
+            Angle in radians for each bin, ascending.
+        """
+        sin = np.clip(
+            np.linspace(-1.0, 1.0, n) / (2 * self.antenna_spacing), -1.0, 1.0)
+        return np.arcsin(sin).astype(np.float32)
+
     @abstractmethod
-    def _asarray(x: Float[np.ndarray, "..."]) -> Float[TArray, "..."]:
+    def _asarray(
+        self, x: Float[np.ndarray, "..."], like: Float32[TArray, "..."]
+    ) -> Float[TArray, "..."]:
         """Convert a numpy array to this backend's array type.
 
         Args:
             x: numpy array to convert.
+            like: array whose device the result should live on, where the
+                backend has a notion of one.
 
         Returns:
             The same values, as a backend array.
@@ -124,19 +127,6 @@ class PointCloud(ABC, Generic[TArray]):
             Peak index, as `(elevation, azimuth)` along the trailing axis.
         """
         ...
-
-    def _prepare(self, cube: Float32[TArray, "..."]) -> None:
-        """Hook called at the top of `__call__`, before any validation.
-
-        Backends which carry device state (e.g. torch) override this to move
-        the bin-to-angle lookup tables to the input's device. The default is
-        a no-op.
-
-        Args:
-            cube: the input passed to
-                [`__call__`][xwr.rsp.PointCloud.__call__].
-        """
-        return
 
     @abstractmethod
     def _point_cloud(
@@ -165,8 +155,8 @@ class PointCloud(ABC, Generic[TArray]):
         """Angle of arrival estimation.
 
         Takes the argmax over the (elevation, azimuth) angle spectrum of each
-        range-doppler bin, yielding **bin indices** into the `el_angles` and
-        `az_angles` lookup tables rather than angles.
+        range-doppler bin, yielding **bin indices** into the
+        [`angle_table`][xwr.rsp.PointCloud.] lookups rather than angles.
 
         !!! warning
 
@@ -213,14 +203,4 @@ class PointCloud(ABC, Generic[TArray]):
                 `z = r sin(el)`; note that the azimuth angle is **negated**,
                 and that `x` is the boresight direction at zero angle.
         """
-        self._prepare(cube)
-
-        _, _, el, az, _ = cube.shape
-        n_el, n_az = self.el_angles.shape[0], self.az_angles.shape[0]
-        if el != n_el or az != n_az:
-            raise ValueError(
-                f"Cube angle shape (el={el}, az={az}) does not match "
-                f"angle_size=({n_el}, {n_az}) "
-                "used to construct this PointCloud.")
-
         return self._point_cloud(cube, mask)

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -96,43 +96,7 @@ class PointCloud(ABC, Generic[TArray]):
             np.linspace(-1.0, 1.0, n) / (2 * self.antenna_spacing), -1.0, 1.0)
         return np.arcsin(sin).astype(np.float32)
 
-    @staticmethod
     @abstractmethod
-    def _argmax_aoa(
-        ang_sptr: Float32[TArray, "... el az"]
-    ) -> Int[TArray, "... 2"]:
-        """Get the (elevation, azimuth) index of the spectrum peak.
-
-        Args:
-            ang_sptr: post fft angle spectrum amplitudes, with the angle axes
-                trailing.
-
-        Returns:
-            Peak index, as `(elevation, azimuth)` along the trailing axis.
-        """
-        ...
-
-    @abstractmethod
-    def _point_cloud(
-        self,
-        cube: Float32[TArray, "batch doppler el az range"],
-        mask: Bool[TArray, "batch range doppler"],
-    ) -> tuple[
-        Bool[TArray, "batch range doppler"],
-        Float32[TArray, "batch range doppler 4"],
-    ]:
-        """Compute the dense point cloud for a validated cube and mask.
-
-        Args:
-            cube: batch of post fft spectrum amplitudes.
-            mask: CFAR detection mask.
-
-        Returns:
-            The same two values as
-                [`__call__`][xwr.rsp.PointCloud.__call__].
-        """
-        ...
-
     def aoa(
         self, cube: Float32[TArray, "batch range doppler el az"]
     ) -> Int[TArray, "batch range doppler 2"]:
@@ -155,8 +119,9 @@ class PointCloud(ABC, Generic[TArray]):
             ang: detect angle index for every range doppler bin, as
                 `(elevation, azimuth)` along the trailing axis.
         """
-        return self._argmax_aoa(cube)
+        ...
 
+    @abstractmethod
     def __call__(
         self,
         cube: Float32[TArray, "batch doppler el az range"],
@@ -187,4 +152,4 @@ class PointCloud(ABC, Generic[TArray]):
                 `z = r sin(el)`; note that the azimuth angle is **negated**,
                 and that `x` is the boresight direction at zero angle.
         """
-        return self._point_cloud(cube, mask)
+        ...

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -60,11 +60,11 @@ class PointCloud(ABC, Generic[TArray]):
 
     Args:
         range_res: range resolution, i.e. meters per range bin; see
-            [`XWRConfig.range_resolution`][xwr.config.]. Defaults to `1.0`,
-            which leaves the range axis in bins.
+            [`XWRConfig.range_resolution`][xwr.config.XWRConfig]. Defaults
+            to `1.0`, which leaves the range axis in bins.
         doppler_res: doppler resolution, i.e. meters/second per doppler bin;
-            see [`XWRConfig.doppler_resolution`][xwr.config.]. Defaults to
-            `1.0`, which leaves the doppler axis in bins.
+            see [`XWRConfig.doppler_resolution`][xwr.config.XWRConfig].
+            Defaults to `1.0`, which leaves the doppler axis in bins.
         angle_fov: angle field of view **in degrees**, for
             (elevation, azimuth).
         antenna_spacing: antenna spacing in terms of wavelength (default 0.5

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -43,9 +43,7 @@ class PointCloud(ABC, Generic[TArray]):
         resolutions of `1.0`, the point cloud is in range/doppler bins instead
         of meters and meters/second.
     - `antenna_spacing` sets the sin-space to angle mapping and must be
-        positive; a non-positive value raises `ValueError`, while a wrong
-        (but positive) value gives systematically wrong angles rather than an
-        error.
+        positive; a non-positive value raises `ValueError`.
     - The bin-to-angle lookup tables are derived from the cube's own angle
         axes on each call, so no angle size has to be declared up front and
         one instance handles cubes of differing angle sizes.
@@ -142,6 +140,13 @@ class PointCloud(ABC, Generic[TArray]):
             yields a point, and the caller is expected to gather the valid
             ones using the returned mask (e.g. `pc[pc_mask]`).
 
+        Implementation notes:
+
+        - Return points are multiplied by `range_res` and `doppler_res` to convert
+            from bins to meters and meters/second, respectively.
+        - Points position compute as `x = r cos(-az) cos(el)`,
+            `y = r sin(-az) cos(el)`, and `z = r sin(el)`
+
         Args:
             cube: batch of post fft spectrum amplitudes.
             mask: CFAR detection mask.
@@ -150,12 +155,6 @@ class PointCloud(ABC, Generic[TArray]):
             mask of valid points, i.e. the CFAR detection mask combined with
                 the angular bounds set by `angle_fov`.
             all possible radar points, where the trailing axis holds
-                `(x, y, z, v)`: position in meters and signed radial velocity
-                in meters/second (in range/doppler bins if `range_res` and
-                `doppler_res` are left at their default of `1.0`). Position is
-                computed as
-                `x = r cos(-az) cos(el)`, `y = r sin(-az) cos(el)`, and
-                `z = r sin(el)`; note that the azimuth angle is **negated**,
-                and that `x` is the boresight direction at zero angle.
+                `(x, y, z, v)`.
         """
         ...

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -53,12 +53,10 @@ class PointCloud(ABC, Generic[TArray]):
     cube's angle axes. A mismatch raises a `ValueError` when
     [`__call__`][xwr.rsp.PointCloud.__call__] is invoked.
 
-    !!! info "Angular field of view"
-
-        `angle_fov` is applied as a symmetric `±fov` bound, and points
-        falling outside it are excluded from the returned mask. This rejects
-        estimates near the edge of the array's sin-space, where a sparse MIMO
-        array has little real resolving power and grating lobes appear.
+    `angle_fov` is applied as a symmetric `±fov` bound, and points falling
+    outside it are excluded from the returned mask. This rejects estimates
+    near the edge of the array's sin-space, where a sparse MIMO array has
+    little real resolving power and grating lobes appear.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -14,9 +14,6 @@ from .generic import TArray
 class DensePoints(Generic[TArray]):
     """A dense radar point cloud, and the points in it which are valid.
 
-    Every range-doppler bin yields a point, so the cloud is *dense*; the
-    caller is expected to gather the valid ones using `mask`.
-
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
             torch `Tensor`.
@@ -58,22 +55,11 @@ class PointCloud(ABC, Generic[TArray]):
 
     Implementation notes:
 
-    - Range bins are mapped by `bin * range_res`, so bin `0` is zero range.
-        Doppler bins are mapped to a *signed* value by
-        `(bin - doppler // 2) * doppler_res`, so the middle bin is zero
-        velocity; this assumes the doppler axis has already been `fftshift`ed,
-        which [`doppler_range`][xwr.rsp.RSP.] does. With the default
-        resolutions of `1.0`, the point cloud is in range/doppler bins instead
-        of meters and meters/second.
-    - `antenna_spacing` sets the sin-space to angle mapping and must be
-        positive; a non-positive value raises `ValueError`.
-    - The bin-to-angle lookup tables are derived from the cube's own angle
-        axes on each call, so no angle size has to be declared up front and
-        one instance handles cubes of differing angle sizes.
-    - `angle_fov` is applied as a symmetric `±fov` bound, and points falling
-        outside it are excluded from the returned mask. This rejects
-        estimates near the edge of the array's sin-space, where a sparse MIMO
-        array has little real resolving power and grating lobes appear.
+    -  With the default range and dopplerresolutions of `1.0`, the point cloud
+        is in range/doppler bins instead of meters and meters/second.
+    - Radars have little resolving power close to the array plane in angle,
+        and suffer from high noise at the edge of the main lobe. Reject these
+        points with `angle_fov`.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
@@ -86,8 +72,8 @@ class PointCloud(ABC, Generic[TArray]):
         doppler_res: doppler resolution, i.e. meters/second per doppler bin;
             see [`XWRConfig.doppler_resolution`][xwr.config.XWRConfig].
             Defaults to `1.0`, which leaves the doppler axis in bins.
-        angle_fov: angle field of view **in degrees**, for
-            (elevation, azimuth).
+        angle_fov: (elevation, azimuth) field of view **in degrees**, where points
+            outside +/-elevation and +/-azimuth are rejected.
         antenna_spacing: antenna spacing in terms of wavelength (default 0.5
             for a half-wavelength grid).
     """

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -1,0 +1,228 @@
+"""Backend-agnostic Angle of Arrival estimation and point cloud."""
+
+from abc import ABC, abstractmethod
+from typing import Generic
+
+import numpy as np
+from jaxtyping import Bool, Float, Float32, Int
+
+from xwr.config import XWRConfig
+
+from .generic import TArray
+
+
+class PointCloud(ABC, Generic[TArray]):
+    """Get radar point cloud from post FFT cube.
+
+    To convert azimuth-elevation bin indices to azimuth-elevation angles,
+    we use the property that the azimuth bin indices correspond to the sin of
+    the angle
+    ```
+    angles = np.arcsin(
+        np.clip(np.linspace(-1.0, 1.0, bin_size) / (2 * antenna_spacing),
+                -1.0, 1.0)
+    )
+    ```
+    where the *corrected* antenna spacing is calculated by
+    ```
+    0.5 * chirp_center_frequency / antenna_design_frequency
+    ```
+
+    !!! info
+
+        The antenna design frequency here refers to the grid alignment of the
+        antenna array, which are typically 0.5 wavelengths apart at some
+        nominal design frequency. Thus, you must correct by a corresponding
+        scale factor when the chirp center frequency differs.
+
+    Only the derived `range_resolution` and `doppler_resolution` are taken
+    from the [`XWRConfig`][xwr.config.]. Range bins are mapped to meters by
+    `bin * range_resolution`, so bin `0` is zero range. Doppler bins are
+    mapped to *signed* radial velocity by
+    `(bin - doppler // 2) * doppler_resolution`, so the middle bin is zero
+    velocity; this assumes the doppler axis has already been `fftshift`ed,
+    which [`doppler_range`][xwr.rsp.RSP.] does.
+
+    `antenna_spacing` sets the sin-space to angle mapping and must be
+    positive; a non-positive value raises `ValueError`, while a wrong (but
+    positive) value gives systematically wrong angles rather than an error.
+
+    `angle_size` **must match the `size={"elevation": ..., "azimuth": ...}`
+    the [`RSP`][xwr.rsp.] was constructed with**: the bin-to-angle lookup
+    tables are built at this length, then indexed by the argmax over the
+    cube's angle axes. A mismatch raises a `ValueError` when
+    [`__call__`][xwr.rsp.PointCloud.__call__] is invoked.
+
+    !!! info "Angular field of view"
+
+        `angle_fov` is applied as a symmetric `±fov` bound, and points
+        falling outside it are excluded from the returned mask. This rejects
+        estimates near the edge of the array's sin-space, where a sparse MIMO
+        array has little real resolving power and grating lobes appear.
+
+    Type Parameters:
+        - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
+            torch `Tensor`.
+
+    Args:
+        config: radar configuration; see [`XWRConfig`][xwr.config.].
+        angle_fov: angle field of view **in degrees**, for
+            (elevation, azimuth).
+        angle_size: angle fft size for (elevation, azimuth).
+        antenna_spacing: antenna spacing in terms of wavelength (default 0.5
+            for a half-wavelength grid).
+    """
+
+    def __init__(
+        self,
+        config: XWRConfig,
+        angle_fov: tuple[float, float] = (20.0, 80.0),
+        angle_size: tuple[int, int] = (128, 128),
+        antenna_spacing: float = 0.5,
+    ) -> None:
+        self.range_res = config.range_resolution
+        self.doppler_res = config.doppler_resolution
+
+        if antenna_spacing <= 0:
+            raise ValueError("antenna_spacing must be > 0")
+        self.el_fov = float(np.deg2rad(angle_fov[0]))
+        self.az_fov = float(np.deg2rad(angle_fov[1]))
+        el_sin = np.clip(
+            np.linspace(-1.0, 1.0, angle_size[0]) / (2 * antenna_spacing),
+            -1.0, 1.0)
+        az_sin = np.clip(
+            np.linspace(-1.0, 1.0, angle_size[1]) / (2 * antenna_spacing),
+            -1.0, 1.0)
+        self.el_angles: Float[TArray, " el"] = self._asarray(
+            np.arcsin(el_sin).astype(np.float32))
+        self.az_angles: Float[TArray, " az"] = self._asarray(
+            np.arcsin(az_sin).astype(np.float32))
+
+    @staticmethod
+    @abstractmethod
+    def _asarray(x: Float[np.ndarray, "..."]) -> Float[TArray, "..."]:
+        """Convert a numpy array to this backend's array type.
+
+        Args:
+            x: numpy array to convert.
+
+        Returns:
+            The same values, as a backend array.
+        """
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def _argmax_aoa(
+        ang_sptr: Float32[TArray, "... el az"]
+    ) -> Int[TArray, "... 2"]:
+        """Get the (elevation, azimuth) index of the spectrum peak.
+
+        Args:
+            ang_sptr: post fft angle spectrum amplitudes, with the angle axes
+                trailing.
+
+        Returns:
+            Peak index, as `(elevation, azimuth)` along the trailing axis.
+        """
+        ...
+
+    def _prepare(self, cube: Float32[TArray, "..."]) -> None:
+        """Hook called at the top of `__call__`, before any validation.
+
+        Backends which carry device state (e.g. torch) override this to move
+        the bin-to-angle lookup tables to the input's device. The default is
+        a no-op.
+
+        Args:
+            cube: the input passed to
+                [`__call__`][xwr.rsp.PointCloud.__call__].
+        """
+        return
+
+    @abstractmethod
+    def _point_cloud(
+        self,
+        cube: Float32[TArray, "batch doppler el az range"],
+        mask: Bool[TArray, "batch range doppler"],
+    ) -> tuple[
+        Bool[TArray, "batch range doppler"],
+        Float32[TArray, "batch range doppler 4"],
+    ]:
+        """Compute the dense point cloud for a validated cube and mask.
+
+        Args:
+            cube: batch of post fft spectrum amplitudes.
+            mask: CFAR detection mask.
+
+        Returns:
+            The same two values as
+                [`__call__`][xwr.rsp.PointCloud.__call__].
+        """
+        ...
+
+    def aoa(
+        self, cube: Float32[TArray, "batch range doppler el az"]
+    ) -> Int[TArray, "batch range doppler 2"]:
+        """Angle of arrival estimation.
+
+        Takes the argmax over the (elevation, azimuth) angle spectrum of each
+        range-doppler bin, yielding **bin indices** into the `el_angles` and
+        `az_angles` lookup tables rather than angles.
+
+        !!! warning
+
+            This assumes at most one scatterer per range-doppler cell; if two
+            targets share a range and velocity, only the stronger is reported.
+
+        Args:
+            cube: batch of post fft spectrum amplitudes, with the angle axes
+                trailing.
+
+        Returns:
+            ang: detect angle index for every range doppler bin, as
+                `(elevation, azimuth)` along the trailing axis.
+        """
+        return self._argmax_aoa(cube)
+
+    def __call__(
+        self,
+        cube: Float32[TArray, "batch doppler el az range"],
+        mask: Bool[TArray, "batch range doppler"],
+    ) -> tuple[
+        Bool[TArray, "batch range doppler"],
+        Float32[TArray, "batch range doppler 4"],
+    ]:
+        """Get point cloud from radar cube and detection mask.
+
+        !!! note
+
+            The returned point cloud is **dense**: every range-doppler bin
+            yields a point, and the caller is expected to gather the valid
+            ones using the returned mask (e.g. `pc[pc_mask]`).
+
+        Args:
+            cube: batch of post fft spectrum amplitudes.
+            mask: CFAR detection mask.
+
+        Returns:
+            mask of valid points, i.e. the CFAR detection mask combined with
+                the angular bounds set by `angle_fov`.
+            all possible radar points, where the trailing axis holds
+                `(x, y, z, v)`: position in meters and signed radial velocity
+                in meters/second. Position is computed as
+                `x = r cos(-az) cos(el)`, `y = r sin(-az) cos(el)`, and
+                `z = r sin(el)`; note that the azimuth angle is **negated**,
+                and that `x` is the boresight direction at zero angle.
+        """
+        self._prepare(cube)
+
+        _, _, el, az, _ = cube.shape
+        n_el, n_az = self.el_angles.shape[0], self.az_angles.shape[0]
+        if el != n_el or az != n_az:
+            raise ValueError(
+                f"Cube angle shape (el={el}, az={az}) does not match "
+                f"angle_size=({n_el}, {n_az}) "
+                "used to construct this PointCloud.")
+
+        return self._point_cloud(cube, mask)

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -6,8 +6,6 @@ from typing import Generic
 import numpy as np
 from jaxtyping import Bool, Float32, Int
 
-from xwr.config import XWRConfig
-
 from .generic import TArray
 
 
@@ -37,13 +35,13 @@ class PointCloud(ABC, Generic[TArray]):
 
     Implementation notes:
 
-    - Only the derived `range_resolution` and `doppler_resolution` are taken
-        from the [`XWRConfig`][xwr.config.]. Range bins are mapped to meters
-        by `bin * range_resolution`, so bin `0` is zero range. Doppler bins
-        are mapped to *signed* radial velocity by
-        `(bin - doppler // 2) * doppler_resolution`, so the middle bin is
-        zero velocity; this assumes the doppler axis has already been
-        `fftshift`ed, which [`doppler_range`][xwr.rsp.RSP.] does.
+    - Range bins are mapped by `bin * range_res`, so bin `0` is zero range.
+        Doppler bins are mapped to a *signed* value by
+        `(bin - doppler // 2) * doppler_res`, so the middle bin is zero
+        velocity; this assumes the doppler axis has already been `fftshift`ed,
+        which [`doppler_range`][xwr.rsp.RSP.] does. With the default
+        resolutions of `1.0`, the point cloud is in range/doppler bins instead
+        of meters and meters/second.
     - `antenna_spacing` sets the sin-space to angle mapping and must be
         positive; a non-positive value raises `ValueError`, while a wrong
         (but positive) value gives systematically wrong angles rather than an
@@ -61,7 +59,12 @@ class PointCloud(ABC, Generic[TArray]):
             torch `Tensor`.
 
     Args:
-        config: radar configuration; see [`XWRConfig`][xwr.config.].
+        range_res: range resolution, i.e. meters per range bin; see
+            [`XWRConfig.range_resolution`][xwr.config.]. Defaults to `1.0`,
+            which leaves the range axis in bins.
+        doppler_res: doppler resolution, i.e. meters/second per doppler bin;
+            see [`XWRConfig.doppler_resolution`][xwr.config.]. Defaults to
+            `1.0`, which leaves the doppler axis in bins.
         angle_fov: angle field of view **in degrees**, for
             (elevation, azimuth).
         antenna_spacing: antenna spacing in terms of wavelength (default 0.5
@@ -70,12 +73,13 @@ class PointCloud(ABC, Generic[TArray]):
 
     def __init__(
         self,
-        config: XWRConfig,
+        range_res: float = 1.0,
+        doppler_res: float = 1.0,
         angle_fov: tuple[float, float] = (20.0, 80.0),
         antenna_spacing: float = 0.5,
     ) -> None:
-        self.range_res = config.range_resolution
-        self.doppler_res = config.doppler_resolution
+        self.range_res = range_res
+        self.doppler_res = doppler_res
 
         if antenna_spacing <= 0:
             raise ValueError("antenna_spacing must be > 0")
@@ -147,7 +151,9 @@ class PointCloud(ABC, Generic[TArray]):
                 the angular bounds set by `angle_fov`.
             all possible radar points, where the trailing axis holds
                 `(x, y, z, v)`: position in meters and signed radial velocity
-                in meters/second. Position is computed as
+                in meters/second (in range/doppler bins if `range_res` and
+                `doppler_res` are left at their default of `1.0`). Position is
+                computed as
                 `x = r cos(-az) cos(el)`, `y = r sin(-az) cos(el)`, and
                 `z = r sin(el)`; note that the azimuth angle is **negated**,
                 and that `x` is the boresight direction at zero angle.

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -1,12 +1,35 @@
 """Backend-agnostic Angle of Arrival estimation and point cloud."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Generic
 
 import numpy as np
 from jaxtyping import Bool, Float32, Int
 
 from .generic import TArray
+
+
+@dataclass
+class DensePoints(Generic[TArray]):
+    """A dense radar point cloud, and the points in it which are valid.
+
+    Every range-doppler bin yields a point, so the cloud is *dense*; the
+    caller is expected to gather the valid ones using `mask`.
+
+    Type Parameters:
+        - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
+            torch `Tensor`.
+
+    Attributes:
+        mask: mask of valid points, i.e. the CFAR detection mask combined with
+            the angular bounds set by `angle_fov`.
+        points: all possible radar points, where the trailing axis holds
+            `(x, y, z, v)`.
+    """
+
+    mask: Bool[TArray, "batch range doppler"]
+    points: Float32[TArray, "batch range doppler 4"]
 
 
 class PointCloud(ABC, Generic[TArray]):
@@ -128,10 +151,7 @@ class PointCloud(ABC, Generic[TArray]):
         self,
         cube: Float32[TArray, "batch doppler el az range"],
         mask: Bool[TArray, "batch range doppler"],
-    ) -> tuple[
-        Bool[TArray, "batch range doppler"],
-        Float32[TArray, "batch range doppler 4"],
-    ]:
+    ) -> DensePoints[TArray]:
         """Get point cloud from radar cube and detection mask.
 
         !!! note
@@ -152,9 +172,7 @@ class PointCloud(ABC, Generic[TArray]):
             mask: CFAR detection mask.
 
         Returns:
-            mask of valid points, i.e. the CFAR detection mask combined with
-                the angular bounds set by `angle_fov`.
-            all possible radar points, where the trailing axis holds
-                `(x, y, z, v)`.
+            The dense point cloud, and the mask of points in it which are
+                valid; see [`DensePoints`][xwr.rsp.].
         """
         ...

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -35,26 +35,26 @@ class PointCloud(ABC, Generic[TArray]):
         nominal design frequency. Thus, you must correct by a corresponding
         scale factor when the chirp center frequency differs.
 
-    Only the derived `range_resolution` and `doppler_resolution` are taken
-    from the [`XWRConfig`][xwr.config.]. Range bins are mapped to meters by
-    `bin * range_resolution`, so bin `0` is zero range. Doppler bins are
-    mapped to *signed* radial velocity by
-    `(bin - doppler // 2) * doppler_resolution`, so the middle bin is zero
-    velocity; this assumes the doppler axis has already been `fftshift`ed,
-    which [`doppler_range`][xwr.rsp.RSP.] does.
+    Implementation notes:
 
-    `antenna_spacing` sets the sin-space to angle mapping and must be
-    positive; a non-positive value raises `ValueError`, while a wrong (but
-    positive) value gives systematically wrong angles rather than an error.
-
-    The bin-to-angle lookup tables are derived from the cube's own angle axes
-    on each call, so no angle size has to be declared up front and one
-    instance handles cubes of differing angle sizes.
-
-    `angle_fov` is applied as a symmetric `±fov` bound, and points falling
-    outside it are excluded from the returned mask. This rejects estimates
-    near the edge of the array's sin-space, where a sparse MIMO array has
-    little real resolving power and grating lobes appear.
+    - Only the derived `range_resolution` and `doppler_resolution` are taken
+        from the [`XWRConfig`][xwr.config.]. Range bins are mapped to meters
+        by `bin * range_resolution`, so bin `0` is zero range. Doppler bins
+        are mapped to *signed* radial velocity by
+        `(bin - doppler // 2) * doppler_resolution`, so the middle bin is
+        zero velocity; this assumes the doppler axis has already been
+        `fftshift`ed, which [`doppler_range`][xwr.rsp.RSP.] does.
+    - `antenna_spacing` sets the sin-space to angle mapping and must be
+        positive; a non-positive value raises `ValueError`, while a wrong
+        (but positive) value gives systematically wrong angles rather than an
+        error.
+    - The bin-to-angle lookup tables are derived from the cube's own angle
+        axes on each call, so no angle size has to be declared up front and
+        one instance handles cubes of differing angle sizes.
+    - `angle_fov` is applied as a symmetric `±fov` bound, and points falling
+        outside it are excluded from the returned mask. This rejects
+        estimates near the edge of the array's sin-space, where a sparse MIMO
+        array has little real resolving power and grating lobes appear.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or

--- a/src/xwr/rsp/aoa.py
+++ b/src/xwr/rsp/aoa.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Generic
 
 import numpy as np
-from jaxtyping import Bool, Float, Float32, Int
+from jaxtyping import Bool, Float32, Int
 
 from xwr.config import XWRConfig
 
@@ -95,22 +95,6 @@ class PointCloud(ABC, Generic[TArray]):
         sin = np.clip(
             np.linspace(-1.0, 1.0, n) / (2 * self.antenna_spacing), -1.0, 1.0)
         return np.arcsin(sin).astype(np.float32)
-
-    @abstractmethod
-    def _asarray(
-        self, x: Float[np.ndarray, "..."], like: Float32[TArray, "..."]
-    ) -> Float[TArray, "..."]:
-        """Convert a numpy array to this backend's array type.
-
-        Args:
-            x: numpy array to convert.
-            like: array whose device the result should live on, where the
-                backend has a notion of one.
-
-        Returns:
-            The same values, as a backend array.
-        """
-        ...
 
     @staticmethod
     @abstractmethod

--- a/src/xwr/rsp/jax/__init__.py
+++ b/src/xwr/rsp/jax/__init__.py
@@ -23,7 +23,7 @@
 from jaxtyping import install_import_hook
 
 with install_import_hook("xwr.rsp.jax", "beartype.beartype"):
-    from .aoa import PointCloud  # noqa: I001
+    from .aoa import PointCloud
     from .rsp import (
         AWR1843AOP,
         AWR2944EVM,

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -1,12 +1,41 @@
 """Backend-agnostic detector (CFAR) base classes."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Generic, cast
 
 import numpy as np
 from jaxtyping import Bool, Float
 
 from .generic import TArray
+
+SignalCube = (
+    Float[TArray, "batch doppler tx rx range"]
+    | Float[TArray, "batch doppler range"]
+    | Float[TArray, "batch doppler el az range"])
+"""Accepted detector input. A virtual array cube, an angle spectrum, or
+    an already-combined range-doppler image.
+"""
+
+
+@dataclass
+class Detection(Generic[TArray]):
+    """Detected objects, and the statistics they were detected from.
+
+    Type Parameters:
+        - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
+            torch `Tensor`.
+
+    Attributes:
+        mask: cfar detected object mask.
+        signal: non-coherently integrated power across the channel axes, i.e.
+            the range-doppler spectrum used for detection.
+        snr: signal to noise ratio, as a linear power ratio.
+    """
+
+    mask: Bool[TArray, "batch range doppler"]
+    signal: Float[TArray, "batch range doppler"]
+    snr: Float[TArray, "batch range doppler"]
 
 
 class Detector(ABC, Generic[TArray]):
@@ -80,11 +109,7 @@ class Detector(ABC, Generic[TArray]):
     @abstractmethod
     def _cfar(
         self, signal_cube: Float[TArray, "batch doppler channel range"]
-    ) -> tuple[
-        Bool[TArray, "batch range doppler"],
-        Float[TArray, "batch range doppler"],
-        Float[TArray, "batch range doppler"],
-    ]:
+    ) -> Detection[TArray]:
         """Run this detector on a batch of radar cubes.
 
         Args:
@@ -93,15 +118,12 @@ class Detector(ABC, Generic[TArray]):
                 single axis.
 
         Returns:
-            The same three values as
-                [`__call__`][xwr.rsp.Detector.__call__].
+            The same detections as [`__call__`][xwr.rsp.Detector.__call__].
         """
         ...
 
     def _flatten(
-        self, signal_cube: Float[TArray, "batch doppler tx rx range"]
-            | Float[TArray, "batch doppler range"]
-            | Float[TArray, "batch doppler el az range"]
+        self, signal_cube: SignalCube
     ) -> Float[TArray, "batch doppler channel range"]:
         """Collapse any axes between doppler and range into a channel axis.
 
@@ -117,15 +139,7 @@ class Detector(ABC, Generic[TArray]):
             signal_cube.shape[0], signal_cube.shape[1], signal_cube.shape[-1])
         return cast(Any, signal_cube).reshape((batch, doppler, -1, rng))
 
-    def __call__(
-        self, signal_cube: Float[TArray, "batch doppler tx rx range"]
-            | Float[TArray, "batch doppler range"]
-            | Float[TArray, "batch doppler el az range"]
-    ) -> tuple[
-        Bool[TArray, "batch range doppler"],
-        Float[TArray, "batch range doppler"],
-        Float[TArray, "batch range doppler"],
-    ]:
+    def __call__(self, signal_cube: SignalCube) -> Detection[TArray]:
         """Run 2D CFAR detection.
 
         !!! note
@@ -141,10 +155,9 @@ class Detector(ABC, Generic[TArray]):
                 across the virtual array.
 
         Returns:
-            cfar detected object mask.
-            non-coherently integrated power across the channel axes, i.e.
-                the range-doppler spectrum used for detection.
-            signal to noise ratio, as a linear power ratio.
+            The detection mask, the range-doppler spectrum it was computed
+                from, and the signal to noise ratio; see
+                [`Detection`][xwr.rsp.].
         """
         return self._cfar(self._flatten(signal_cube))
 

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -38,13 +38,8 @@ class Detection(Generic[TArray]):
     snr: Float[TArray, "batch range doppler"]
 
 
-class Detector(ABC, Generic[TArray]):
-    """Abstract, backend-agnostic constant false alarm rate detector.
-
-    This class documents the interface shared by every CFAR variant: given a
-    batch of post range-doppler FFT radar cubes, report which range-doppler
-    cells hold a target. Concrete detectors differ in how they estimate the
-    noise floor.
+class CFAR(ABC, Generic[TArray]):
+    """Abstract, backend-agnostic CFAR base class.
 
     The following implementations are available:
 
@@ -52,29 +47,6 @@ class Detector(ABC, Generic[TArray]):
     |----------|----------------|
     | [`CFAR`][xwr.rsp.] | 2D cell-averaging ring |
     | [`CFARCASO`][xwr.rsp.] | Separate "smallest of" tests on the range and doppler axes |
-
-    Implementation notes:
-
-    - Every variant takes a batch of range-doppler cubes and is parameterized
-        the same way, with the `guard` and `train` sizes corresponding to the
-        (range, doppler) axes and counted on **each** side of the cell under
-        test. `guard`, `train`, and `discard_range` must all be `>= 0`; a
-        negative value raises `ValueError`.
-    - The input may be a virtual array cube
-        (`batch doppler tx rx range`), an angle spectrum
-        (`batch doppler el az range`), or an already-combined range-doppler
-        image (`batch doppler range`). Whatever sits between the doppler and
-        range axes is flattened into a single channel axis and integrated
-        non-coherently, so a range-doppler image is simply treated as having
-        one channel.
-    - Guard cells sit between the cell under test and the training cells and
-        are excluded from the noise estimate, absorbing target energy spread
-        by FFT sidelobes and windowing which would otherwise raise the
-        target's own noise floor. Training cells sit outside them and form
-        the estimate.
-    - The closest range bins are dominated by TX to RX leakage and DC, and
-        the furthest are past useful SNR. Bins inside `discard_range` are
-        forced to non-detect and assigned unit noise.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
@@ -156,13 +128,12 @@ class Detector(ABC, Generic[TArray]):
 
         Returns:
             The detection mask, the range-doppler spectrum it was computed
-                from, and the signal to noise ratio; see
-                [`Detection`][xwr.rsp.].
+                from, and the signal to noise ratio.
         """
         return self._cfar(self._flatten(signal_cube))
 
 
-class CFAR(Detector[TArray], ABC):
+class CACFAR(CFAR[TArray], ABC):
     """Cell-averaging CFAR.
 
     ```
@@ -177,17 +148,10 @@ class CFAR(Detector[TArray], ABC):
 
     Implementation notes:
 
-    - The noise floor is the mean of the training cells in the 2D ring, so
-        the cell under test is tested once. The window half-width on each
-        axis is `guard + train`; `train` may be `0` on one axis, training on
-        the other axis only, but `0` on both leaves an empty ring and raises
-        `ValueError`.
+    - The noise floor is the mean of the training cells in the 2D ring.
+    - `train` can be `0` on at most one axis.
     - A cell is detected when its integrated power exceeds
-        `snr_thresh * noise`. Raising the threshold gives fewer false alarms
-        and a lower probability of detection.
-
-    See [`Detector`][xwr.rsp.] for the shared `guard`, `train`, and
-    `discard_range` semantics.
+        `snr_thresh * noise`.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
@@ -223,7 +187,7 @@ class CFAR(Detector[TArray], ABC):
         self.mask: Float[np.ndarray, "kr kd"] = mask
 
 
-class CFARCASO(Detector[TArray], ABC):
+class CASOCFAR(CFAR[TArray], ABC):
     """Cell-averaging Smallest of CFAR.
 
     !!! info
@@ -246,19 +210,11 @@ class CFARCASO(Detector[TArray], ABC):
 
     Implementation notes:
 
-    - Rather than averaging both sides of the cell under test, CASO
-        ("smallest of") takes the **minimum** of the two one-sided means, so
+    - On each axis, CASO takes the **minimum** of the two one-sided means, so
         a strong target on one side cannot inflate the noise floor and mask a
-        weaker target on the other. `train` must be `>= 1` on both axes,
-        since each one-sided mean divides by it, and the asymmetric default
-        `guard` reflects that range leakage is broad while doppler needs no
-        guard.
+        weaker target on the other. As such, `train` must be `>= 1` on both axes.
     - An axis fires where its integrated power exceeds that axis's
-        `snr_thresh * noise`. Raising a threshold gives fewer false alarms
-        and a lower probability of detection.
-
-    See [`Detector`][xwr.rsp.] for the shared `guard`, `train`, and
-    `discard_range` semantics.
+        `snr_thresh * noise`. Both axes must fire for a detection to be reported.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -45,8 +45,8 @@ class CFAR(ABC, Generic[TArray]):
 
     | Detector | Noise estimate |
     |----------|----------------|
-    | [`CFAR`][xwr.rsp.] | 2D cell-averaging ring |
-    | [`CFARCASO`][xwr.rsp.] | Separate "smallest of" tests on the range and doppler axes |
+    | [`CACFAR`][xwr.rsp.] | 2D cell-averaging ring |
+    | [`CASOCFAR`][xwr.rsp.] | Separate "smallest of" tests on the range and doppler axes |
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
@@ -90,7 +90,7 @@ class CFAR(ABC, Generic[TArray]):
                 single axis.
 
         Returns:
-            The same detections as [`__call__`][xwr.rsp.Detector.__call__].
+            The same detections as [`__call__`][xwr.rsp.CFAR.__call__].
         """
         ...
 
@@ -192,7 +192,7 @@ class CASOCFAR(CFAR[TArray], ABC):
 
     !!! info
 
-        Instead of the 2D kernel used in [`CFAR`][xwr.rsp.], CASO uses a
+        Instead of the 2D kernel used in [`CACFAR`][xwr.rsp.], CASO uses a
         separate 1D kernel for the range and doppler axes, and reports a
         detection only where **both** axes fire.
 

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -21,16 +21,19 @@ class Detector(ABC, Generic[TArray]):
         cell-averaging ring, and [`CFARCASO`][xwr.rsp.] for separate
         "smallest of" tests on the range and doppler axes.
 
-    Every variant is parameterized the same way. Guard cells sit between the
-    cell under test and the training cells and are excluded from the noise
-    estimate; training cells sit outside them and form it. Both are counted
-    on **each** side, for (range, doppler).
+    Every variant takes a batch of range-doppler cubes and is parameterized
+    the same way, with the `guard` and `train` sizes corresponding to the
+    (range, doppler) axes and counted on **each** side of the cell under
+    test.
 
-    !!! info "Discarded range bins"
+    Guard cells sit between the cell under test and the training cells and
+    are excluded from the noise estimate, absorbing target energy spread by
+    FFT sidelobes and windowing which would otherwise raise the target's own
+    noise floor. Training cells sit outside them and form the estimate.
 
-        The closest range bins are dominated by TX to RX leakage and DC, and
-        the furthest are past useful SNR. Bins inside `discard_range` are
-        forced to non-detect and assigned unit noise.
+    The closest range bins are dominated by TX to RX leakage and DC, and the
+    furthest are past useful SNR. Bins inside `discard_range` are forced to
+    non-detect and assigned unit noise.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
@@ -117,9 +120,6 @@ class Detector(ABC, Generic[TArray]):
 class CFAR(Detector[TArray], ABC):
     """Cell-averaging CFAR.
 
-    Expects a batch of range-doppler cubes, with the `guard` and `train`
-    sizes corresponding to the (range, doppler) axes.
-
     ```
         ┌─────────────────┐ ▲ guard[0]+train[0]
         │    ┌───────┐    │ │
@@ -131,25 +131,16 @@ class CFAR(Detector[TArray], ABC):
     ```
 
     The noise floor is the mean of the training cells in the 2D ring, so the
-    cell under test is tested once; contrast [`CFARCASO`][xwr.rsp.], which
-    tests the range and doppler axes separately and requires **both** to
-    fire. The window half-width on each axis is `guard + train`.
-
-    Guard cells are excluded from the noise estimate: they absorb target
-    energy spread by FFT sidelobes and windowing, which would otherwise
-    raise the target's own noise floor. `train` may be `0` on one axis,
-    training on the other axis only; `0` on both leaves an empty ring and
-    raises `ValueError`.
+    cell under test is tested once. The window half-width on each axis is
+    `guard + train`; `train` may be `0` on one axis, training on the other
+    axis only, but `0` on both leaves an empty ring and raises `ValueError`.
 
     A cell is detected when its integrated power exceeds
     `snr_thresh * noise`. Raising the threshold gives fewer false alarms and
     a lower probability of detection.
 
-    !!! info "Discarded range bins"
-
-        The closest range bins are dominated by TX to RX leakage and DC, and
-        the furthest are past useful SNR. Bins inside `discard_range` are
-        forced to non-detect and assigned unit noise.
+    See [`Detector`][xwr.rsp.] for the shared `guard`, `train`, and
+    `discard_range` semantics.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
@@ -201,14 +192,11 @@ class CFAR(Detector[TArray], ABC):
 class CFARCASO(Detector[TArray], ABC):
     """Cell-averaging Smallest of CFAR.
 
-    Expects a batch of range-doppler cubes, with the `guard` and
-    `train` sizes corresponding to the (range, doppler) axes.
-
     !!! info
 
-        Instead of the 2D kernel used in Cell-averaging CFAR, CASO uses
-        a separate 1D kernel for the range and doppler axes; detection occurs
-        if the SNR exceeds the specified threshold on either axis.
+        Instead of the 2D kernel used in [`CFAR`][xwr.rsp.], CASO uses a
+        separate 1D kernel for the range and doppler axes, and reports a
+        detection only where **both** axes fire.
 
     ```
                ┌─┐       ▲ train[0]
@@ -226,23 +214,15 @@ class CFARCASO(Detector[TArray], ABC):
     of") takes the **minimum** of the two one-sided means, so a strong target
     on one side cannot inflate the noise floor and mask a weaker target on
     the other. `train` must be `>= 1` on both axes, since each one-sided mean
-    divides by it.
-
-    Guard cells are excluded from the noise estimate: they absorb target
-    energy spread by FFT sidelobes and windowing, which would otherwise raise
-    the target's own noise floor. The asymmetric default reflects that range
+    divides by it, and the asymmetric default `guard` reflects that range
     leakage is broad while doppler needs no guard.
 
-    A cell is detected on an axis when its integrated power exceeds
-    `snr_thresh * noise` for that axis, and a detection is reported only
-    where **both** axes fire. Raising a threshold gives fewer false alarms
-    and a lower probability of detection.
+    An axis fires where its integrated power exceeds that axis's
+    `snr_thresh * noise`. Raising a threshold gives fewer false alarms and a
+    lower probability of detection.
 
-    !!! info "Discarded range bins"
-
-        The closest range bins are dominated by TX to RX leakage and DC, and
-        the furthest are past useful SNR. Bins inside `discard_range` are
-        forced to non-detect and assigned unit noise.
+    See [`Detector`][xwr.rsp.] for the shared `guard`, `train`, and
+    `discard_range` semantics.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -1,0 +1,276 @@
+"""Backend-agnostic detector (CFAR) base classes."""
+
+from abc import ABC, abstractmethod
+from typing import Generic
+
+import numpy as np
+from jaxtyping import Bool, Float
+
+from .generic import TArray
+
+
+class Detector(ABC, Generic[TArray]):
+    """Abstract, backend-agnostic constant false alarm rate detector.
+
+    !!! info
+
+        This class documents the interface shared by every CFAR variant:
+        given a batch of post range-doppler FFT radar cubes, report which
+        range-doppler cells hold a target. Concrete detectors differ in how
+        they estimate the noise floor; see [`CFAR`][xwr.rsp.] for a 2D
+        cell-averaging ring, and [`CFARCASO`][xwr.rsp.] for separate
+        "smallest of" tests on the range and doppler axes.
+
+    Every variant is parameterized the same way. Guard cells sit between the
+    cell under test and the training cells and are excluded from the noise
+    estimate; training cells sit outside them and form it. Both are counted
+    on **each** side, for (range, doppler).
+
+    !!! info "Discarded range bins"
+
+        The closest range bins are dominated by TX to RX leakage and DC, and
+        the furthest are past useful SNR. Bins inside `discard_range` are
+        forced to non-detect and assigned unit noise.
+
+    Type Parameters:
+        - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
+            torch `Tensor`.
+
+    Args:
+        guard: guard cells on each side of the cell under test, for
+            (range, doppler).
+        train: training cells on each side of the guard region, for
+            (range, doppler).
+        discard_range: range bins (close, far) to discard around DC.
+    """
+
+    def __init__(
+        self,
+        guard: tuple[int, int],
+        train: tuple[int, int],
+        discard_range: tuple[int, int] = (10, 20),
+    ) -> None:
+        # A negative guard or train silently corrupts the window geometry
+        # instead of raising: the derived half-width `guard + train` can fall
+        # below `guard`, so the guard region wraps to the far edge and the
+        # cell under test is never excluded from its own noise estimate.
+        if any(g < 0 for g in guard):
+            raise ValueError(f"Guard {guard} must be >= 0 on each axis.")
+        if any(t < 0 for t in train):
+            raise ValueError(f"Train {train} must be >= 0 on each axis.")
+        if any(d < 0 for d in discard_range):
+            raise ValueError(
+                f"Discard range {discard_range} must be >= 0 on each side.")
+
+        self.guard = guard
+        self.train = train
+        # discard detect object around DC
+        self.discard_r = discard_range
+
+    @abstractmethod
+    def _cfar(
+        self, signal_cube: Float[TArray, "batch doppler tx rx range"]
+    ) -> tuple[
+        Bool[TArray, "batch range doppler"],
+        Float[TArray, "batch range doppler"],
+        Float[TArray, "batch range doppler"],
+    ]:
+        """Run this detector on a batch of radar cubes.
+
+        Args:
+            signal_cube: batch of post range doppler FFT radar cubes in
+                amplitude.
+
+        Returns:
+            The same three values as
+                [`__call__`][xwr.rsp.Detector.__call__].
+        """
+        ...
+
+    def __call__(
+        self, signal_cube: Float[TArray, "batch doppler tx rx range"]
+    ) -> tuple[
+        Bool[TArray, "batch range doppler"],
+        Float[TArray, "batch range doppler"],
+        Float[TArray, "batch range doppler"],
+    ]:
+        """Run 2D CFAR detection.
+
+        !!! note
+
+            The transmit and receive antenna axes are combined
+            non-coherently, so their relative order does not matter.
+
+        Args:
+            signal_cube: batch of post range doppler FFT radar cubes in
+                amplitude.
+
+        Returns:
+            cfar detected object mask.
+            non-coherently integrated power across the virtual array, i.e.
+                the range-doppler spectrum used for detection.
+            signal to noise ratio, as a linear power ratio.
+        """
+        return self._cfar(signal_cube)
+
+
+class CFAR(Detector[TArray], ABC):
+    """Cell-averaging CFAR.
+
+    Expects a batch of range-doppler cubes, with the `guard` and `train`
+    sizes corresponding to the (range, doppler) axes.
+
+    ```
+        ┌─────────────────┐ ▲ guard[0]+train[0]
+        │    ┌───────┐    │ │
+        │    │  ┌─┐  │    │ ▼
+        │    │  └─┘  │    │ ▲ guard[0]
+        │    └───────┘    │ ▼
+        └─────────────────┘
+    guard[1] ◄──► ◄───────► guard[1]+train[1]
+    ```
+
+    The noise floor is the mean of the training cells in the 2D ring, so the
+    cell under test is tested once; contrast [`CFARCASO`][xwr.rsp.], which
+    tests the range and doppler axes separately and requires **both** to
+    fire. The window half-width on each axis is `guard + train`.
+
+    Guard cells are excluded from the noise estimate: they absorb target
+    energy spread by FFT sidelobes and windowing, which would otherwise
+    raise the target's own noise floor. `train` may be `0` on one axis,
+    training on the other axis only; `0` on both leaves an empty ring and
+    raises `ValueError`.
+
+    A cell is detected when its integrated power exceeds
+    `snr_thresh * noise`. Raising the threshold gives fewer false alarms and
+    a lower probability of detection.
+
+    !!! info "Discarded range bins"
+
+        The closest range bins are dominated by TX to RX leakage and DC, and
+        the furthest are past useful SNR. Bins inside `discard_range` are
+        forced to non-detect and assigned unit noise.
+
+    Type Parameters:
+        - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
+            torch `Tensor`.
+
+    Args:
+        guard: guard cells on each side of the cell under test, for
+            (range, doppler).
+        train: training cells on each side of the guard region, for
+            (range, doppler).
+        snr_thresh: detection threshold, as a **linear power ratio** (not dB).
+        discard_range: range bins (close, far) to discard around DC.
+    """
+
+    def __init__(
+        self,
+        guard: tuple[int, int] = (2, 2),
+        train: tuple[int, int] = (2, 2),
+        snr_thresh: float = 5.0,
+        discard_range: tuple[int, int] = (10, 20),
+    ) -> None:
+        super().__init__(guard, train, discard_range)
+        self.snr_thresh = snr_thresh
+
+        g0, g1 = guard
+        w0, w1 = g0 + train[0], g1 + train[1]
+
+        mask = np.ones((2 * w0 + 1, 2 * w1 + 1), dtype=np.float32)
+        mask[w0 - g0 : w0 + g0 + 1, w1 - g1 : w1 + g1 + 1] = 0.0
+        if mask.sum() == 0:
+            raise ValueError(
+                f"CFAR mask is empty; check guard={guard} and train={train}.")
+        self.mask: Float[TArray, "kr kd"] = self._asarray(mask)
+
+    @staticmethod
+    @abstractmethod
+    def _asarray(x: Float[np.ndarray, "..."]) -> Float[TArray, "..."]:
+        """Convert a numpy array to this backend's array type.
+
+        Args:
+            x: numpy array to convert.
+
+        Returns:
+            The same values, as a backend array.
+        """
+        ...
+
+
+class CFARCASO(Detector[TArray], ABC):
+    """Cell-averaging Smallest of CFAR.
+
+    Expects a batch of range-doppler cubes, with the `guard` and
+    `train` sizes corresponding to the (range, doppler) axes.
+
+    !!! info
+
+        Instead of the 2D kernel used in Cell-averaging CFAR, CASO uses
+        a separate 1D kernel for the range and doppler axes; detection occurs
+        if the SNR exceeds the specified threshold on either axis.
+
+    ```
+               ┌─┐       ▲ train[0]
+               │ │       │
+               ├─┤       ▼
+         ┌───┬─┼─┼─┬───┐
+         └───┴─┼─┼─┴───┘ ▲ guard[0]
+               ├─┤       ▼
+               │ │
+               └─┘
+    guard[1] ◄─►   ◄───► train[1]
+    ```
+
+    Rather than averaging both sides of the cell under test, CASO ("smallest
+    of") takes the **minimum** of the two one-sided means, so a strong target
+    on one side cannot inflate the noise floor and mask a weaker target on
+    the other. `train` must be `>= 1` on both axes, since each one-sided mean
+    divides by it.
+
+    Guard cells are excluded from the noise estimate: they absorb target
+    energy spread by FFT sidelobes and windowing, which would otherwise raise
+    the target's own noise floor. The asymmetric default reflects that range
+    leakage is broad while doppler needs no guard.
+
+    A cell is detected on an axis when its integrated power exceeds
+    `snr_thresh * noise` for that axis, and a detection is reported only
+    where **both** axes fire. Raising a threshold gives fewer false alarms
+    and a lower probability of detection.
+
+    !!! info "Discarded range bins"
+
+        The closest range bins are dominated by TX to RX leakage and DC, and
+        the furthest are past useful SNR. Bins inside `discard_range` are
+        forced to non-detect and assigned unit noise.
+
+    Type Parameters:
+        - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
+            torch `Tensor`.
+
+    Args:
+        guard: guard cells on each side of the cell under test, for
+            (range, doppler).
+        train: training cells on each side of the guard region, for
+            (range, doppler).
+        snr_thresh: detection threshold for (range, doppler), as a **linear
+            power ratio** (not dB).
+        discard_range: range bins (close, far) to discard around DC.
+    """
+
+    def __init__(
+        self,
+        guard: tuple[int, int] = (8, 0),
+        train: tuple[int, int] = (8, 4),
+        snr_thresh: tuple[float, float] = (5.0, 3.0),
+        discard_range: tuple[int, int] = (10, 20),
+    ) -> None:
+        super().__init__(guard, train, discard_range)
+        if any(t < 1 for t in train):
+            raise ValueError(f"Train {train} must be >= 1 on each axis.")
+
+        self.snr_r, self.snr_d = snr_thresh
+
+        self.train_r, self.train_d = train
+        self.pad_r = train[0] + guard[0]
+        self.pad_d = train[1] + guard[1]

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -12,28 +12,33 @@ from .generic import TArray
 class Detector(ABC, Generic[TArray]):
     """Abstract, backend-agnostic constant false alarm rate detector.
 
-    !!! info
+    This class documents the interface shared by every CFAR variant: given a
+    batch of post range-doppler FFT radar cubes, report which range-doppler
+    cells hold a target. Concrete detectors differ in how they estimate the
+    noise floor.
 
-        This class documents the interface shared by every CFAR variant:
-        given a batch of post range-doppler FFT radar cubes, report which
-        range-doppler cells hold a target. Concrete detectors differ in how
-        they estimate the noise floor; see [`CFAR`][xwr.rsp.] for a 2D
-        cell-averaging ring, and [`CFARCASO`][xwr.rsp.] for separate
-        "smallest of" tests on the range and doppler axes.
+    The following implementations are available:
 
-    Every variant takes a batch of range-doppler cubes and is parameterized
-    the same way, with the `guard` and `train` sizes corresponding to the
-    (range, doppler) axes and counted on **each** side of the cell under
-    test.
+    | Detector | Noise estimate |
+    |----------|----------------|
+    | [`CFAR`][xwr.rsp.] | 2D cell-averaging ring |
+    | [`CFARCASO`][xwr.rsp.] | Separate "smallest of" tests on the range and doppler axes |
 
-    Guard cells sit between the cell under test and the training cells and
-    are excluded from the noise estimate, absorbing target energy spread by
-    FFT sidelobes and windowing which would otherwise raise the target's own
-    noise floor. Training cells sit outside them and form the estimate.
+    Implementation notes:
 
-    The closest range bins are dominated by TX to RX leakage and DC, and the
-    furthest are past useful SNR. Bins inside `discard_range` are forced to
-    non-detect and assigned unit noise.
+    - Every variant takes a batch of range-doppler cubes and is parameterized
+        the same way, with the `guard` and `train` sizes corresponding to the
+        (range, doppler) axes and counted on **each** side of the cell under
+        test. `guard`, `train`, and `discard_range` must all be `>= 0`; a
+        negative value raises `ValueError`.
+    - Guard cells sit between the cell under test and the training cells and
+        are excluded from the noise estimate, absorbing target energy spread
+        by FFT sidelobes and windowing which would otherwise raise the
+        target's own noise floor. Training cells sit outside them and form
+        the estimate.
+    - The closest range bins are dominated by TX to RX leakage and DC, and
+        the furthest are past useful SNR. Bins inside `discard_range` are
+        forced to non-detect and assigned unit noise.
 
     Type Parameters:
         - `TArray`: Generic backend, e.g., `np.ndarray`, jax `jax.Array`, or
@@ -53,10 +58,6 @@ class Detector(ABC, Generic[TArray]):
         train: tuple[int, int],
         discard_range: tuple[int, int] = (10, 20),
     ) -> None:
-        # A negative guard or train silently corrupts the window geometry
-        # instead of raising: the derived half-width `guard + train` can fall
-        # below `guard`, so the guard region wraps to the far edge and the
-        # cell under test is never excluded from its own noise estimate.
         if any(g < 0 for g in guard):
             raise ValueError(f"Guard {guard} must be >= 0 on each axis.")
         if any(t < 0 for t in train):
@@ -67,7 +68,6 @@ class Detector(ABC, Generic[TArray]):
 
         self.guard = guard
         self.train = train
-        # discard detect object around DC
         self.discard_r = discard_range
 
     @abstractmethod
@@ -130,14 +130,16 @@ class CFAR(Detector[TArray], ABC):
     guard[1] ◄──► ◄───────► guard[1]+train[1]
     ```
 
-    The noise floor is the mean of the training cells in the 2D ring, so the
-    cell under test is tested once. The window half-width on each axis is
-    `guard + train`; `train` may be `0` on one axis, training on the other
-    axis only, but `0` on both leaves an empty ring and raises `ValueError`.
+    Implementation notes:
 
-    A cell is detected when its integrated power exceeds
-    `snr_thresh * noise`. Raising the threshold gives fewer false alarms and
-    a lower probability of detection.
+    - The noise floor is the mean of the training cells in the 2D ring, so
+        the cell under test is tested once. The window half-width on each
+        axis is `guard + train`; `train` may be `0` on one axis, training on
+        the other axis only, but `0` on both leaves an empty ring and raises
+        `ValueError`.
+    - A cell is detected when its integrated power exceeds
+        `snr_thresh * noise`. Raising the threshold gives fewer false alarms
+        and a lower probability of detection.
 
     See [`Detector`][xwr.rsp.] for the shared `guard`, `train`, and
     `discard_range` semantics.
@@ -210,16 +212,18 @@ class CFARCASO(Detector[TArray], ABC):
     guard[1] ◄─►   ◄───► train[1]
     ```
 
-    Rather than averaging both sides of the cell under test, CASO ("smallest
-    of") takes the **minimum** of the two one-sided means, so a strong target
-    on one side cannot inflate the noise floor and mask a weaker target on
-    the other. `train` must be `>= 1` on both axes, since each one-sided mean
-    divides by it, and the asymmetric default `guard` reflects that range
-    leakage is broad while doppler needs no guard.
+    Implementation notes:
 
-    An axis fires where its integrated power exceeds that axis's
-    `snr_thresh * noise`. Raising a threshold gives fewer false alarms and a
-    lower probability of detection.
+    - Rather than averaging both sides of the cell under test, CASO
+        ("smallest of") takes the **minimum** of the two one-sided means, so
+        a strong target on one side cannot inflate the noise floor and mask a
+        weaker target on the other. `train` must be `>= 1` on both axes,
+        since each one-sided mean divides by it, and the asymmetric default
+        `guard` reflects that range leakage is broad while doppler needs no
+        guard.
+    - An axis fires where its integrated power exceeds that axis's
+        `snr_thresh * noise`. Raising a threshold gives fewer false alarms
+        and a lower probability of detection.
 
     See [`Detector`][xwr.rsp.] for the shared `guard`, `train`, and
     `discard_range` semantics.

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -220,20 +220,7 @@ class CFAR(Detector[TArray], ABC):
         if mask.sum() == 0:
             raise ValueError(
                 f"CFAR mask is empty; check guard={guard} and train={train}.")
-        self.mask: Float[TArray, "kr kd"] = self._asarray(mask)
-
-    @staticmethod
-    @abstractmethod
-    def _asarray(x: Float[np.ndarray, "..."]) -> Float[TArray, "..."]:
-        """Convert a numpy array to this backend's array type.
-
-        Args:
-            x: numpy array to convert.
-
-        Returns:
-            The same values, as a backend array.
-        """
-        ...
+        self.mask: Float[np.ndarray, "kr kd"] = mask
 
 
 class CFARCASO(Detector[TArray], ABC):

--- a/src/xwr/rsp/spectrum.py
+++ b/src/xwr/rsp/spectrum.py
@@ -1,7 +1,7 @@
 """Backend-agnostic detector (CFAR) base classes."""
 
 from abc import ABC, abstractmethod
-from typing import Generic
+from typing import Any, Generic, cast
 
 import numpy as np
 from jaxtyping import Bool, Float
@@ -31,6 +31,13 @@ class Detector(ABC, Generic[TArray]):
         (range, doppler) axes and counted on **each** side of the cell under
         test. `guard`, `train`, and `discard_range` must all be `>= 0`; a
         negative value raises `ValueError`.
+    - The input may be a virtual array cube
+        (`batch doppler tx rx range`), an angle spectrum
+        (`batch doppler el az range`), or an already-combined range-doppler
+        image (`batch doppler range`). Whatever sits between the doppler and
+        range axes is flattened into a single channel axis and integrated
+        non-coherently, so a range-doppler image is simply treated as having
+        one channel.
     - Guard cells sit between the cell under test and the training cells and
         are excluded from the noise estimate, absorbing target energy spread
         by FFT sidelobes and windowing which would otherwise raise the
@@ -72,7 +79,7 @@ class Detector(ABC, Generic[TArray]):
 
     @abstractmethod
     def _cfar(
-        self, signal_cube: Float[TArray, "batch doppler tx rx range"]
+        self, signal_cube: Float[TArray, "batch doppler channel range"]
     ) -> tuple[
         Bool[TArray, "batch range doppler"],
         Float[TArray, "batch range doppler"],
@@ -82,7 +89,8 @@ class Detector(ABC, Generic[TArray]):
 
         Args:
             signal_cube: batch of post range doppler FFT radar cubes in
-                amplitude.
+                amplitude, with the channel axes already flattened into a
+                single axis.
 
         Returns:
             The same three values as
@@ -90,8 +98,29 @@ class Detector(ABC, Generic[TArray]):
         """
         ...
 
+    def _flatten(
+        self, signal_cube: Float[TArray, "batch doppler tx rx range"]
+            | Float[TArray, "batch doppler range"]
+            | Float[TArray, "batch doppler el az range"]
+    ) -> Float[TArray, "batch doppler channel range"]:
+        """Collapse any axes between doppler and range into a channel axis.
+
+        Args:
+            signal_cube: batch of post range doppler FFT radar cubes in
+                amplitude.
+
+        Returns:
+            The same values, with a single channel axis; a range-doppler
+                image gains a channel axis of length 1.
+        """
+        batch, doppler, rng = (
+            signal_cube.shape[0], signal_cube.shape[1], signal_cube.shape[-1])
+        return cast(Any, signal_cube).reshape((batch, doppler, -1, rng))
+
     def __call__(
         self, signal_cube: Float[TArray, "batch doppler tx rx range"]
+            | Float[TArray, "batch doppler range"]
+            | Float[TArray, "batch doppler el az range"]
     ) -> tuple[
         Bool[TArray, "batch range doppler"],
         Float[TArray, "batch range doppler"],
@@ -101,20 +130,23 @@ class Detector(ABC, Generic[TArray]):
 
         !!! note
 
-            The transmit and receive antenna axes are combined
-            non-coherently, so their relative order does not matter.
+            The channel axes (the transmit and receive antennas of the
+            virtual array, or the elevation and azimuth bins of an angle
+            spectrum) are combined non-coherently, so their relative order
+            does not matter.
 
         Args:
             signal_cube: batch of post range doppler FFT radar cubes in
-                amplitude.
+                amplitude, or a range-doppler image which is already combined
+                across the virtual array.
 
         Returns:
             cfar detected object mask.
-            non-coherently integrated power across the virtual array, i.e.
+            non-coherently integrated power across the channel axes, i.e.
                 the range-doppler spectrum used for detection.
             signal to noise ratio, as a linear power ratio.
         """
-        return self._cfar(signal_cube)
+        return self._cfar(self._flatten(signal_cube))
 
 
 class CFAR(Detector[TArray], ABC):


### PR DESCRIPTION
Adds backend-agnostic base classes to `xwr.rsp`, mirroring the per-backend `aoa.py` / `spectrum.py` layout, so the jax, numpy, and torch backends can share one contract instead of triplicating it:

- `Detector` is the root for both CFAR variants, holding what they genuinely share: `guard` / `train` / `discard_range` storage and validation, and the `__call__` docstring and return contract, delegating to an abstract `_cfar`.
- `CFAR` and `CFARCASO` subclass it with their own defaults, `snr_thresh` type, and derived state (ring mask vs. pad/train scalars).
- `PointCloud` holds the bin-to-angle lookup table construction and `aoa`