### PR TITLE
batched jax point cloud and SNR-based CFAR

### DIFF
--- a/demo/rerun_pc.py
+++ b/demo/rerun_pc.py
@@ -15,7 +15,7 @@ from roverd.sensors.radar import RadarMetadata
 from tqdm import tqdm
 
 from xwr.rsp import RSP, iq_from_iiqq
-from xwr.rsp.jax import CFARCASO, AWR1843Boost, PointCloud
+from xwr.rsp.jax import CASOCFAR, AWR1843Boost, PointCloud
 
 
 def main(
@@ -51,7 +51,7 @@ def main(
         size={"azimuth": azimuth_size, "elevation": elevation_size},
         window={"range": True, "doppler": True},
     )
-    cfar = CFARCASO()
+    cfar = CASOCFAR()
     radar_pc = PointCloud(
         radar_cfg.range_resolution[0].item(),
         radar_cfg.doppler_resolution[0].item(),
@@ -63,10 +63,11 @@ def main(
         cube = rsp.elevation_azimuth(cube_rd)
 
         detection = cfar.__call__(jnp.abs(cube_rd.squeeze()))
-        pc_mask, pc = radar_pc.__call__(
+        points = radar_pc.__call__(
             jnp.abs(cube.squeeze()), detection.mask)
 
-        return detection.mask, cube_rd.squeeze(), pc_mask, pc
+        return (
+            detection.mask, cube_rd.squeeze(), points.mask, points.points)
 
     cmap = plt.get_cmap("hot")
     rr.init("radar_vis")

--- a/demo/rerun_pc.py
+++ b/demo/rerun_pc.py
@@ -62,10 +62,11 @@ def main(
         cube_rd = rsp.doppler_range(iq)
         cube = rsp.elevation_azimuth(cube_rd)
 
-        rd_mask, sig, snr = cfar.__call__(jnp.abs(cube_rd.squeeze()))
-        pc_mask, pc = radar_pc.__call__(jnp.abs(cube.squeeze()), rd_mask)
+        detection = cfar.__call__(jnp.abs(cube_rd.squeeze()))
+        pc_mask, pc = radar_pc.__call__(
+            jnp.abs(cube.squeeze()), detection.mask)
 
-        return rd_mask, cube_rd.squeeze(), pc_mask, pc
+        return detection.mask, cube_rd.squeeze(), pc_mask, pc
 
     cmap = plt.get_cmap("hot")
     rr.init("radar_vis")

--- a/src/xwr/rsp/jax/__init__.py
+++ b/src/xwr/rsp/jax/__init__.py
@@ -32,7 +32,7 @@ with install_import_hook("xwr.rsp.jax", "beartype.beartype"):
         AWR1843Boost,
         RSPJax,
     )
-    from .spectrum import CFAR, CFARCASO, CalibratedSpectrum
+    from .spectrum import CACFAR, CASOCFAR, CalibratedSpectrum
 
 __all__ = [
     "AWR1642Boost",
@@ -41,8 +41,8 @@ __all__ = [
     "AWR2944EVM",
     "AWRL6844EVM",
     "RSPJax",
-    "CFAR",
-    "CFARCASO",
+    "CACFAR",
+    "CASOCFAR",
     "CalibratedSpectrum",
     "PointCloud"
 ]

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -10,8 +10,9 @@ from xwr.rsp import aoa as base
 class PointCloud(base.PointCloud[Array]):
     """Get radar point cloud from post FFT cube."""
 
-    @staticmethod
-    def _asarray(x: Float[np.ndarray, "..."]) -> Float[Array, "..."]:
+    def _asarray(
+        self, x: Float[np.ndarray, "..."], like: Float32[Array, "..."]
+    ) -> Float[Array, "..."]:
         return jnp.asarray(x)
 
     @staticmethod
@@ -30,14 +31,17 @@ class PointCloud(base.PointCloud[Array]):
         Bool[Array, "batch range doppler"],
         Float32[Array, "batch range doppler 4"],
     ]:
+        el_angles = self._asarray(self.angle_table(cube.shape[2]), cube)
+        az_angles = self._asarray(self.angle_table(cube.shape[3]), cube)
+
         _, r_size, d_size = mask.shape
         range_v = jnp.arange(r_size) * self.range_res
         doppler_v = (jnp.arange(d_size) - d_size // 2) * self.doppler_res
         r_grid, d_grid = jnp.meshgrid(range_v, doppler_v, indexing="ij")
 
         angle_idx = self.aoa(cube.transpose(0, 4, 1, 2, 3))
-        ang_e = self.el_angles[angle_idx[..., 0]]
-        ang_a = self.az_angles[angle_idx[..., 1]]
+        ang_e = el_angles[angle_idx[..., 0]]
+        ang_a = az_angles[angle_idx[..., 1]]
         mask_e = jnp.logical_and(ang_e < self.el_fov, ang_e > -self.el_fov)
         mask_a = jnp.logical_and(ang_a < self.az_fov, ang_a > -self.az_fov)
         mask_ang = jnp.logical_and(mask_a, mask_e)

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -1,19 +1,13 @@
 """Angle of Arrival Estimation and Point Cloud Module using JAX."""
 
-import numpy as np
 from jax import numpy as jnp
-from jaxtyping import Array, Bool, Float, Float32, Int
+from jaxtyping import Array, Bool, Float32, Int
 
 from xwr.rsp import aoa as base
 
 
 class PointCloud(base.PointCloud[Array]):
     """Get radar point cloud from post FFT cube."""
-
-    def _asarray(
-        self, x: Float[np.ndarray, "..."], like: Float32[Array, "..."]
-    ) -> Float[Array, "..."]:
-        return jnp.asarray(x)
 
     def aoa(
         self, cube: Float32[Array, "batch range doppler el az"]
@@ -30,15 +24,16 @@ class PointCloud(base.PointCloud[Array]):
         Bool[Array, "batch range doppler"],
         Float32[Array, "batch range doppler 4"],
     ]:
-        el_angles = self._asarray(self._angle_table(cube.shape[2]), cube)
-        az_angles = self._asarray(self._angle_table(cube.shape[3]), cube)
+        el_angles = jnp.asarray(self._angle_table(cube.shape[2]))
+        az_angles = jnp.asarray(self._angle_table(cube.shape[3]))
 
         _, r_size, d_size = mask.shape
         range_v = jnp.arange(r_size) * self.range_res
         doppler_v = (jnp.arange(d_size) - d_size // 2) * self.doppler_res
         r_grid, d_grid = jnp.meshgrid(range_v, doppler_v, indexing="ij")
 
-        angle_idx = self.aoa(cube.transpose(0, 4, 1, 2, 3))
+        # (batch doppler el az range) -> (batch range doppler el az)
+        angle_idx = self.aoa(jnp.moveaxis(cube, -1, 1))
         ang_e = el_angles[angle_idx[..., 0]]
         ang_a = az_angles[angle_idx[..., 1]]
         mask_e = jnp.logical_and(ang_e < self.el_fov, ang_e > -self.el_fov)

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -30,8 +30,8 @@ class PointCloud(base.PointCloud[Array]):
         Bool[Array, "batch range doppler"],
         Float32[Array, "batch range doppler 4"],
     ]:
-        el_angles = self._asarray(self.angle_table(cube.shape[2]), cube)
-        az_angles = self._asarray(self.angle_table(cube.shape[3]), cube)
+        el_angles = self._asarray(self._angle_table(cube.shape[2]), cube)
+        az_angles = self._asarray(self._angle_table(cube.shape[3]), cube)
 
         _, r_size, d_size = mask.shape
         range_v = jnp.arange(r_size) * self.range_res

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -6,10 +6,10 @@ from jaxtyping import Array, Bool, Float32, Int
 
 from xwr.rsp import aoa as base
 
+# Register [`DensePoints`][xwr.rsp.] as a pytree, so that it can be
+# returned from a `jax.jit`-ed function.
 jax.tree_util.register_dataclass(
     base.DensePoints, data_fields=["mask", "points"], meta_fields=[])
-"""Register [`DensePoints`][xwr.rsp.] as a pytree, so that it can be
-returned from a `jax.jit`-ed function."""
 
 
 class PointCloud(base.PointCloud[Array]):

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -15,15 +15,14 @@ class PointCloud(base.PointCloud[Array]):
     ) -> Float[Array, "..."]:
         return jnp.asarray(x)
 
-    @staticmethod
-    def _argmax_aoa(ang_sptr: Float32[Array, "... el az"]) -> Int[
-        Array, "... 2"
-    ]:
-        el, az = ang_sptr.shape[-2:]
-        idx = jnp.argmax(ang_sptr.reshape(*ang_sptr.shape[:-2], el * az), -1)
+    def aoa(
+        self, cube: Float32[Array, "batch range doppler el az"]
+    ) -> Int[Array, "batch range doppler 2"]:
+        el, az = cube.shape[-2:]
+        idx = jnp.argmax(cube.reshape(*cube.shape[:-2], el * az), -1)
         return jnp.stack((idx // az, idx % az), axis=-1)
 
-    def _point_cloud(
+    def __call__(
         self,
         cube: Float32[Array, "batch doppler el az range"],
         mask: Bool[Array, "batch range doppler"],

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -1,129 +1,51 @@
 """Angle of Arrival Estimation and Point Cloud Module using JAX."""
 
-from collections.abc import Sequence
-
-import jax
+import numpy as np
 from jax import numpy as jnp
-from jaxtyping import Array, Bool, Float32, Int
+from jaxtyping import Array, Bool, Float, Float32, Int
+
+from xwr.rsp import aoa as base
 
 
-class PointCloud:
-    """Get radar point cloud from post FFT cube.
-
-    To convert azimuth-elevation bin indices to azimuth-elevation angles,
-    we use the property that the azimuth bin indices correspond to the sin of
-    the angle
-    ```
-    angles = jnp.arcsin(
-        jnp.linspace(-jnp.pi, jnp.pi, bin_size)
-        / (2 * jnp.pi * antenna_spacing)
-    )
-    ```
-    where the *corrected* antenna spacing is calculated by
-    ```
-    0.5 * chirp_center_frequency / antenna_design_frequency
-    ```
-
-    !!! info
-
-        The antenna design frequency here refers to the grid alignment of the
-        antenna array, which are typically 0.5 wavelengths apart at some
-        nominal design frequency. Thus, you must correct by a corresponding
-        scale factor when the chirp center frequency differs.
-
-    Args:
-        range_resolution: range fft resolution
-        doppler_resolution: doppler fft resolution
-        angle_fov: angle field of view in degrees for (elevation, azimuth).
-        angle_size: angle fft size for (elevation, azimuth).
-        antenna_spacing: antenna spacing in terms of wavelength (default 0.5).
-    """
-
-    def __init__(
-        self,
-        range_resolution: float,
-        doppler_resolution: float,
-        angle_fov: Sequence[float] = (20.0, 80.0),
-        angle_size: Sequence[int] = (128, 128),
-        antenna_spacing: float = 0.5,
-    ) -> None:
-        self.range_res = range_resolution
-        self.doppler_res = doppler_resolution
-
-        assert len(angle_fov) == 2 and len(angle_size) == 2, (
-            "angle_fov and angle_size must be a sequence of length 2."
-        )
-        self.ele_fov = jnp.deg2rad(angle_fov[0])
-        self.azi_fov = jnp.deg2rad(angle_fov[1])
-        self.ele_angles = jnp.arcsin(
-            jnp.linspace(-jnp.pi, jnp.pi, angle_size[0])
-            / (2 * jnp.pi * antenna_spacing)
-        )
-        self.azi_angles = jnp.arcsin(
-            jnp.linspace(-jnp.pi, jnp.pi, angle_size[1])
-            / (2 * jnp.pi * antenna_spacing)
-        )
+class PointCloud(base.PointCloud[Array]):
+    """Get radar point cloud from post FFT cube."""
 
     @staticmethod
-    def _argmax_aoa(ang_sptr: Float32[Array, "ele azi"]) -> tuple[Array, ...]:
-        """Argmax for angle of arrival estimation.
+    def _asarray(x: Float[np.ndarray, "..."]) -> Float[Array, "..."]:
+        return jnp.asarray(x)
 
-        Args:
-            ang_sptr: post fft angle spectrum amplitude in 2D.
+    @staticmethod
+    def _argmax_aoa(ang_sptr: Float32[Array, "... el az"]) -> Int[
+        Array, "... 2"
+    ]:
+        el, az = ang_sptr.shape[-2:]
+        idx = jnp.argmax(ang_sptr.reshape(*ang_sptr.shape[:-2], el * az), -1)
+        return jnp.stack((idx // az, idx % az), axis=-1)
 
-        Returns:
-            detected angle index (elevation, azimuth).
-        """
-        idx = jnp.argmax(ang_sptr)
-        idx2d = jnp.unravel_index(idx, ang_sptr.shape)
-        return idx2d
-
-    def aoa(
-        self, cube: Float32[Array, "range doppler ele azi"]
-    ) -> Int[Array, "range doppler 2"]:
-        """Angle of arrival estimation.
-
-        Args:
-            cube: post fft spectrum amplitude.
-
-        Returns:
-            ang: detect angle index for every range doppler bin.
-        """
-        idxs = jax.vmap(jax.vmap(self._argmax_aoa))(cube)
-        ang = jnp.stack((idxs), axis=-1)
-        return ang
-
-    def __call__(
+    def _point_cloud(
         self,
-        cube: Float32[Array, "doppler ele azi range"],
-        mask: Bool[Array, "range doppler"],
-    ) -> tuple[Bool[Array, "range doppler"], Float32[Array, "range doppler 4"]]:
-        """Get point cloud from radar cube and detection mask.
-
-        Args:
-            cube: post fft spectrum amplitude.
-            mask: CFAR detection mask.
-
-        Returns:
-            mask of valid points (given the specified angular bounds)
-            all possible radar points
-        """
-        r_size, d_size = mask.shape
+        cube: Float32[Array, "batch doppler el az range"],
+        mask: Bool[Array, "batch range doppler"],
+    ) -> tuple[
+        Bool[Array, "batch range doppler"],
+        Float32[Array, "batch range doppler 4"],
+    ]:
+        _, r_size, d_size = mask.shape
         range_v = jnp.arange(r_size) * self.range_res
         doppler_v = (jnp.arange(d_size) - d_size // 2) * self.doppler_res
         r_grid, d_grid = jnp.meshgrid(range_v, doppler_v, indexing="ij")
 
-        angle_idx = self.aoa(cube.transpose(3, 0, 1, 2))
-        ang_e = self.ele_angles[angle_idx[:, :, 0]]
-        ang_a = self.azi_angles[angle_idx[:, :, 1]]
-        mask_e = jnp.logical_and(ang_e < self.ele_fov, ang_e > -self.ele_fov)
-        mask_a = jnp.logical_and(ang_a < self.azi_fov, ang_a > -self.azi_fov)
+        angle_idx = self.aoa(cube.transpose(0, 4, 1, 2, 3))
+        ang_e = self.el_angles[angle_idx[..., 0]]
+        ang_a = self.az_angles[angle_idx[..., 1]]
+        mask_e = jnp.logical_and(ang_e < self.el_fov, ang_e > -self.el_fov)
+        mask_a = jnp.logical_and(ang_a < self.az_fov, ang_a > -self.az_fov)
         mask_ang = jnp.logical_and(mask_a, mask_e)
 
         x = r_grid * jnp.cos(-ang_a) * jnp.cos(ang_e)
         y = r_grid * jnp.sin(-ang_a) * jnp.cos(ang_e)
         z = r_grid * jnp.sin(ang_e)
-        v = d_grid
+        v = jnp.broadcast_to(d_grid, x.shape)
 
         pc_mask = jnp.logical_and(mask, mask_ang)
         pc = jnp.stack((x, y, z, v), axis=-1)

--- a/src/xwr/rsp/jax/aoa.py
+++ b/src/xwr/rsp/jax/aoa.py
@@ -1,9 +1,15 @@
 """Angle of Arrival Estimation and Point Cloud Module using JAX."""
 
+import jax
 from jax import numpy as jnp
 from jaxtyping import Array, Bool, Float32, Int
 
 from xwr.rsp import aoa as base
+
+jax.tree_util.register_dataclass(
+    base.DensePoints, data_fields=["mask", "points"], meta_fields=[])
+"""Register [`DensePoints`][xwr.rsp.] as a pytree, so that it can be
+returned from a `jax.jit`-ed function."""
 
 
 class PointCloud(base.PointCloud[Array]):
@@ -20,10 +26,7 @@ class PointCloud(base.PointCloud[Array]):
         self,
         cube: Float32[Array, "batch doppler el az range"],
         mask: Bool[Array, "batch range doppler"],
-    ) -> tuple[
-        Bool[Array, "batch range doppler"],
-        Float32[Array, "batch range doppler 4"],
-    ]:
+    ) -> base.DensePoints[Array]:
         el_angles = jnp.asarray(self._angle_table(cube.shape[2]))
         az_angles = jnp.asarray(self._angle_table(cube.shape[3]))
 
@@ -48,4 +51,4 @@ class PointCloud(base.PointCloud[Array]):
         pc_mask = jnp.logical_and(mask, mask_ang)
         pc = jnp.stack((x, y, z, v), axis=-1)
 
-        return pc_mask, pc
+        return base.DensePoints(pc_mask, pc)

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -17,18 +17,19 @@ TRSP = TypeVar("TRSP", bound=RSPJax)
 
 
 def _integrate(
-    signal_cube: Float[Array, "batch doppler tx rx range"]
+    signal_cube: Float[Array, "batch doppler channel range"]
 ) -> Float[Array, "batch range doppler"]:
-    """Combine the virtual array non-coherently into a range-doppler image.
+    """Combine the channel axis non-coherently into a range-doppler image.
 
     Args:
-        signal_cube: batch of post range doppler FFT radar cubes in amplitude.
+        signal_cube: batch of post range doppler FFT radar cubes in amplitude,
+            flattened to a single channel axis.
 
     Returns:
         Integrated power, offset by 1 so that an empty cell has unit power
             instead of dividing by zero downstream.
     """
-    return jnp.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
+    return jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
 
 
 class CFAR(base.CFAR[Array]):
@@ -49,7 +50,7 @@ class CFAR(base.CFAR[Array]):
         return convolve2d(signal, self.mask, mode="same") / valid
 
     def _cfar(
-        self, signal_cube: Float[Array, "batch doppler tx rx range"]
+        self, signal_cube: Float[Array, "batch doppler channel range"]
     ) -> tuple[
         Bool[Array, "batch range doppler"],
         Float[Array, "batch range doppler"],
@@ -117,7 +118,7 @@ class CFARCASO(base.CFARCASO[Array]):
         return cut > snr * noise, noise
 
     def _cfar(
-        self, signal_cube: Float[Array, "batch doppler tx rx range"]
+        self, signal_cube: Float[Array, "batch doppler channel range"]
     ) -> tuple[
         Bool[Array, "batch range doppler"],
         Float[Array, "batch range doppler"],

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -3,7 +3,6 @@
 from typing import Generic, TypeVar
 
 import jax
-import numpy as np
 from jax import numpy as jnp
 from jax.scipy.signal import convolve2d
 from jaxtyping import Array, Bool, Complex64, Float, Float32, Int16
@@ -24,19 +23,16 @@ from a `jax.jit`-ed function."""
 class CFAR(base.CFAR[Array]):
     """Cell-averaging CFAR."""
 
-    @staticmethod
-    def _asarray(x: Float[np.ndarray, "..."]) -> Float[Array, "..."]:
-        return jnp.asarray(x)
-
     def _noise(
         self, signal: Float[Array, "range doppler"]
     ) -> Float[Array, "range doppler"]:
         """Get the ring-averaged noise floor for a range-doppler image."""
+        mask = jnp.asarray(self.mask)
         # Jax currently only supports 'fill', but this should be changed to
         # 'wrap' if they ever decide to add support; the training cell count
         # is normalized out to compensate at the edges.
-        valid = convolve2d(jnp.ones_like(signal), self.mask, mode="same")
-        return convolve2d(signal, self.mask, mode="same") / valid
+        valid = convolve2d(jnp.ones_like(signal), mask, mode="same")
+        return convolve2d(signal, mask, mode="same") / valid
 
     def _cfar(
         self, signal_cube: Float[Array, "batch doppler channel range"]

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -14,10 +14,10 @@ from .rsp import RSPJax
 
 TRSP = TypeVar("TRSP", bound=RSPJax)
 
+# Rgister [`Detection`][xwr.rsp.] as a pytree, so that it can be
+# returned from a `jax.jit`-ed function.
 jax.tree_util.register_dataclass(
     base.Detection, data_fields=["mask", "signal", "snr"], meta_fields=[])
-"""Register [`Detection`][xwr.rsp.] as a pytree, so that it can be returned
-from a `jax.jit`-ed function."""
 
 
 class CACFAR(base.CACFAR[Array]):

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -15,6 +15,11 @@ from .rsp import RSPJax
 
 TRSP = TypeVar("TRSP", bound=RSPJax)
 
+jax.tree_util.register_dataclass(
+    base.Detection, data_fields=["mask", "signal", "snr"], meta_fields=[])
+"""Register [`Detection`][xwr.rsp.] as a pytree, so that it can be returned
+from a `jax.jit`-ed function."""
+
 
 class CFAR(base.CFAR[Array]):
     """Cell-averaging CFAR."""
@@ -35,11 +40,7 @@ class CFAR(base.CFAR[Array]):
 
     def _cfar(
         self, signal_cube: Float[Array, "batch doppler channel range"]
-    ) -> tuple[
-        Bool[Array, "batch range doppler"],
-        Float[Array, "batch range doppler"],
-        Float[Array, "batch range doppler"],
-    ]:
+    ) -> base.Detection[Array]:
         # Non-coherent integration over the channel axis, offset by 1 so
         # that an empty cell has unit power instead of dividing by zero.
         signal = jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
@@ -57,7 +58,7 @@ class CFAR(base.CFAR[Array]):
         obj_mask = jnp.zeros(signal.shape, dtype=bool).at[
             :, near : s_r - far].set(snr[:, near : s_r - far] > self.snr_thresh)
 
-        return obj_mask, signal, snr
+        return base.Detection(obj_mask, signal, snr)
 
 
 class CFARCASO(base.CFARCASO[Array]):
@@ -107,11 +108,7 @@ class CFARCASO(base.CFARCASO[Array]):
 
     def _cfar(
         self, signal_cube: Float[Array, "batch doppler channel range"]
-    ) -> tuple[
-        Bool[Array, "batch range doppler"],
-        Float[Array, "batch range doppler"],
-        Float[Array, "batch range doppler"],
-    ]:
+    ) -> base.Detection[Array]:
         # Non-coherent integration over the channel axis, offset by 1 so
         # that an empty cell has unit power instead of dividing by zero.
         signal = jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
@@ -145,7 +142,7 @@ class CFARCASO(base.CFARCASO[Array]):
         snr = signal / noise
         obj_mask = jnp.logical_and(detect_r, detect_d)
 
-        return obj_mask, signal, snr
+        return base.Detection(obj_mask, signal, snr)
 
 
 class CalibratedSpectrum(Generic[TRSP]):

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -1,6 +1,5 @@
 """Calibrated Spectrum Processing."""
 
-from collections.abc import Sequence
 from typing import Generic, TypeVar
 
 import jax
@@ -10,231 +9,147 @@ from jax.scipy.signal import convolve2d
 from jaxtyping import Array, Bool, Complex64, Float, Float32, Int16
 
 from xwr.rsp import iq_from_iiqq
+from xwr.rsp import spectrum as base
 
 from .rsp import RSPJax
 
 TRSP = TypeVar("TRSP", bound=RSPJax)
 
 
-class CFAR:
-    """Cell-averaging CFAR.
-
-    Expects a 2d input, with the `guard` and `window` sizes corresponding to
-    the respective input axes.
-
-    ```
-        ┌─────────────────┐ ▲ window[0]
-        │    ┌───────┐    │ │
-        │    │  ┌─┐  │    │ ▼
-        │    │  └─┘  │    │ ▲ guard[0]
-        │    └───────┘    │ ▼
-        └─────────────────┘
-    guard[1] ◄──► ◄───────► window[1]
-    ```
-
-    !!! note
-
-        The user is responsible for applying the desired thresholding.
-        For example, when using a gaussian model, the threshold should be
-        calculated using an inverse normal CDF (e.g. `scipy.stats.norm.isf`):
-
-        ```python
-        cfar = CFAR(guard=(2, 2), window=(4, 4))
-        thresholds = cfar(image)
-        mask = (thresholds > scipy.stats.norm.isf(0.01))
-        ```
+def _integrate(
+    signal_cube: Float[Array, "batch doppler tx rx range"]
+) -> Float[Array, "batch range doppler"]:
+    """Combine the virtual array non-coherently into a range-doppler image.
 
     Args:
-        guard: size of guard cells (excluded from noise estimation).
-        window: total CFAR window size.
+        signal_cube: batch of post range doppler FFT radar cubes in amplitude.
+
+    Returns:
+        Integrated power, offset by 1 so that an empty cell has unit power
+            instead of dividing by zero downstream.
     """
+    return jnp.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
 
-    def __init__(
-        self, guard: tuple[int, int] = (2, 2), window: tuple[int, int] = (4, 4)
-    ) -> None:
-        w0, w1 = window
-        g0, g1 = guard
 
-        mask = np.ones((2 * w0 + 1, 2 * w1 + 1), dtype=np.float32)
-        mask[w0 - g0 : w0 + g0 + 1, w1 - g1 : w1 + g1 + 1] = 0.0
-        self.mask: Array = jnp.array(mask)
+class CFAR(base.CFAR[Array]):
+    """Cell-averaging CFAR."""
 
-    def __call__(self, x: Float[Array, "d r ..."]) -> Float[Array, "d r"]:
-        """Get CFAR thresholds.
+    @staticmethod
+    def _asarray(x: Float[np.ndarray, "..."]) -> Float[Array, "..."]:
+        return jnp.asarray(x)
 
-        !!! note
-
-            Boundary cells are zero-padded.
-
-        Args:
-            x: input. If more than 2 axes are present, the additional axes
-                are averaged before running CFAR.
-
-        Returns:
-            CFAR threshold values for this input.
-        """
-        # Collapse additional axes if required
-        if x.ndim > 2:
-            x = jnp.mean(x.reshape(x.shape[0], x.shape[1], -1), -1)
-
+    def _noise(
+        self, signal: Float[Array, "range doppler"]
+    ) -> Float[Array, "range doppler"]:
+        """Get the ring-averaged noise floor for a range-doppler image."""
         # Jax currently only supports 'fill', but this should be changed to
-        # 'wrap' if they ever decide to add support.
-        valid = convolve2d(jnp.ones_like(x), self.mask, mode="same")
-        mu = convolve2d(x, self.mask, mode="same") / valid
-        second_moment = convolve2d(x**2, self.mask, mode="same") / valid
-        sigma = jnp.sqrt(second_moment - mu**2)
+        # 'wrap' if they ever decide to add support; the training cell count
+        # is normalized out to compensate at the edges.
+        valid = convolve2d(jnp.ones_like(signal), self.mask, mode="same")
+        return convolve2d(signal, self.mask, mode="same") / valid
 
-        return (x - mu) / sigma
+    def _cfar(
+        self, signal_cube: Float[Array, "batch doppler tx rx range"]
+    ) -> tuple[
+        Bool[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+    ]:
+        signal = _integrate(signal_cube)
+        _, s_r, _ = signal.shape
+
+        noise_r = jax.vmap(self._noise)(signal)
+
+        near, far = self.discard_r[0], self.discard_r[1]
+        # 1 outside the discarded band, so the reported SNR there is the raw
+        # signal rather than a division by zero.
+        noise = jnp.ones_like(signal).at[:, near : s_r - far].set(
+            noise_r[:, near : s_r - far])
+
+        snr = signal / noise
+        obj_mask = jnp.zeros(signal.shape, dtype=bool).at[
+            :, near : s_r - far].set(snr[:, near : s_r - far] > self.snr_thresh)
+
+        return obj_mask, signal, snr
 
 
-class CFARCASO:
-    """Cell-averaging Smallest of CFAR.
-
-    Expects a 2d input, with the `guard` and `window` sizes corresponding to
-    the respective input axes.
-
-    !!! info
-
-        Instead of the 2D kernel used in Cell-averaging CFAR, CASO uses
-        a separate 1D kernel for the range and doppler axes; detection occurs
-        if the SNR exceeds the specified threshold on either axis.
-
-    ```
-               ┌─┐       ▲ window[0]
-               │ │       │
-               ├─┤       ▼
-         ┌───┬─┼─┼─┬───┐
-         └───┴─┼─┼─┴───┘ ▲ guard[0]
-               ├─┤       ▼
-               │ │
-               └─┘
-    guard[1] ◄─►   ◄───► window[1]
-    ```
-
-    Args:
-        train_window: training window size for (range, doppler).
-        guard_window: guard window size for (range, doppler).
-        snr_thresh: signal to noise ratio threshold for (range, doppler).
-        discard_range: range bins (close, far) to discard around DC.
-    """
-
-    def __init__(
-        self,
-        train_window: Sequence[int] = (8, 4),
-        guard_window: Sequence[int] = (8, 0),
-        snr_thresh: Sequence[float] = (5.0, 3.0),
-        discard_range: Sequence[int] = (10, 20),
-    ):
-        if len(train_window) != 2:
-            raise ValueError(f"Train window {train_window} must be length 2.")
-        if len(guard_window) != 2:
-            raise ValueError(f"Guard window {guard_window} must be length 2.")
-        if len(discard_range) != 2:
-            raise ValueError(
-                f"Discard range {discard_range} must be length 2.")
-        if len(snr_thresh) != 2:
-            raise ValueError(f"SNR thresh {snr_thresh} must be length 2.")
-
-        # discard detect object around DC
-        self.discard_r = discard_range
-        self.snr_r, self.snr_d = snr_thresh
-
-        self.pad_r = train_window[0] + guard_window[0]
-        self.pad_d = train_window[1] + guard_window[1]
-
-        # caso
-        def make_caso_kernels(train, pad):
-            ker = np.zeros((2 * pad + 1), dtype=np.float32)
-            ker_a, ker_b = ker.copy(), ker.copy()
-            ker_a[:train], ker_b[-train:] = 1, 1
-            ker_a /= ker_a.sum()
-            ker_b /= ker_b.sum()
-            return jnp.asarray(ker_a), jnp.asarray(ker_b)
-
-        self.r_ker_a, self.r_ker_b = make_caso_kernels(
-            train_window[0], self.pad_r)
-        self.d_ker_a, self.d_ker_b = make_caso_kernels(
-            train_window[1], self.pad_d)
+class CFARCASO(base.CFARCASO[Array]):
+    """Cell-averaging Smallest of CFAR."""
 
     @staticmethod
     def _caso(
-        signal: Float32[Array, "n"],
-        ker_a: Float32[Array, "w"],
-        ker_b: Float32[Array, "w"],
-        snr: float,
+        signal: Float[Array, "..."],
+        axis: int,
+        train: int,
         pad: int,
-    ) -> tuple[Bool[Array, "m"], Float32[Array, "m"]]:
-        """1D CFAR CASO.
+        snr: float,
+    ) -> tuple[Bool[Array, "..."], Float[Array, "..."]]:
+        """Run 1D CFAR CASO along `axis` of an arbitrarily batched array.
+
+        The training cells are a contiguous box on each side of the cell under
+        test, so the leading and trailing one-sided means are accumulated
+        directly from shifted slices rather than correlated against a mostly
+        zero kernel. `train` is a static Python int, so the sum unrolls at
+        trace time.
 
         Args:
-            signal: 1D frequency spectrum.
-            ker_a: one side cfar kernel.
-            ker_b: one side cfar kernel.
-            snr: signal to noise ratio threshold.
-            pad: padding number of the input signal.
+            signal: signal, already padded by `pad` on both ends of `axis`.
+            axis: axis to run CFAR along.
+            train: number of training cells on each side.
+            pad: number of training plus guard cells on each side.
+            snr: signal to noise ratio threshold, as a linear power ratio.
 
         Returns:
-            detection mask.
-            noise level.
+            detection mask and noise level, with `axis` trimmed by `2 * pad`
+                back to the unpadded length.
         """
-        cor_a = jnp.correlate(signal, ker_a, mode="valid")
-        cor_b = jnp.correlate(signal, ker_b, mode="valid")
-        noise = jnp.minimum(cor_a, cor_b)
-        detect = signal[pad:-pad] > snr * noise
-        return detect, noise
+        size = signal.shape[axis] - 2 * pad
 
-    def __call__(
-        self, signal_cube: Float32[Array, "doppler Rx Tx range"]
+        def one_sided(start: int) -> Float[Array, "..."]:
+            acc = jax.lax.slice_in_dim(signal, start, start + size, axis=axis)
+            for i in range(1, train):
+                acc = acc + jax.lax.slice_in_dim(
+                    signal, start + i, start + i + size, axis=axis)
+            return acc / train
+
+        noise = jnp.minimum(one_sided(0), one_sided(2 * pad + 1 - train))
+        cut = jax.lax.slice_in_dim(signal, pad, pad + size, axis=axis)
+        return cut > snr * noise, noise
+
+    def _cfar(
+        self, signal_cube: Float[Array, "batch doppler tx rx range"]
     ) -> tuple[
-        Bool[Array, "range doppler"],
-        Float32[Array, "range doppler"],
-        Float32[Array, "range doppler"],
+        Bool[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
+        Float[Array, "batch range doppler"],
     ]:
-        """Run 2D CFAR CASO.
+        signal = _integrate(signal_cube)
+        _, s_r, _ = signal.shape
 
-        Args:
-            signal_cube: post range doppler FFT radar cube in amplitude.
-
-        Returns:
-            cfar detected object mask.
-            range doppler spectrum for detection.
-            signal to noise ratio.
-        """
-        signal_cube = signal_cube.transpose(3, 0, 1, 2)
-        s_r, s_d, _, _ = signal_cube.shape
-        range_dopp = signal_cube.reshape(s_r, s_d, -1)
-
-        # non-coherent signal combination along the antenna array
-        signal = jnp.sum(range_dopp**2, axis=-1) + 1
-        sig_discard = signal[self.discard_r[0] : -self.discard_r[1]]
+        near, far = self.discard_r[0], self.discard_r[1]
+        sig_discard = signal[:, near : s_r - far]
         sig_pad_r = jnp.concat(
             (
-                sig_discard[: self.pad_r],
+                sig_discard[:, : self.pad_r],
                 sig_discard,
-                sig_discard[-self.pad_r :],
+                sig_discard[:, -self.pad_r :],
             ),
-            axis=0,
+            axis=1,
         )
         sig_pad_d = jnp.pad(
-            signal, ((0, 0), (self.pad_d, self.pad_d)), mode="wrap"
+            signal, ((0, 0), (0, 0), (self.pad_d, self.pad_d)), mode="wrap"
         )
 
         # detection
-        detect_r, noise = jax.vmap(
-            self._caso, in_axes=(1, None, None, None, None)
-        )(sig_pad_r, self.r_ker_a, self.r_ker_b, self.snr_r, self.pad_r)
-        detect_r, noise = detect_r.swapaxes(0, 1), noise.swapaxes(0, 1)
-        detect_r = jnp.pad(
-            detect_r, ((self.discard_r[0], self.discard_r[1]), (0, 0))
-        )
+        detect_r, noise_r = self._caso(
+            sig_pad_r, 1, self.train_r, self.pad_r, self.snr_r)
+        detect_r = jnp.pad(detect_r, ((0, 0), (near, far), (0, 0)))
+        # 1 outside the discarded band, so the reported SNR there is the raw
+        # signal rather than a division by zero.
         noise = jnp.pad(
-            noise,
-            ((self.discard_r[0], self.discard_r[1]), (0, 0)),
-            constant_values=1,
-        )
-        detect_d, _ = jax.vmap(self._caso, in_axes=(0, None, None, None, None))(
-            sig_pad_d, self.d_ker_a, self.d_ker_b, self.snr_d, self.pad_d
-        )
+            noise_r, ((0, 0), (near, far), (0, 0)), constant_values=1)
+        detect_d, _ = self._caso(
+            sig_pad_d, 2, self.train_d, self.pad_d, self.snr_d)
 
         snr = signal / noise
         obj_mask = jnp.logical_and(detect_r, detect_d)

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -16,22 +16,6 @@ from .rsp import RSPJax
 TRSP = TypeVar("TRSP", bound=RSPJax)
 
 
-def _integrate(
-    signal_cube: Float[Array, "batch doppler channel range"]
-) -> Float[Array, "batch range doppler"]:
-    """Combine the channel axis non-coherently into a range-doppler image.
-
-    Args:
-        signal_cube: batch of post range doppler FFT radar cubes in amplitude,
-            flattened to a single channel axis.
-
-    Returns:
-        Integrated power, offset by 1 so that an empty cell has unit power
-            instead of dividing by zero downstream.
-    """
-    return jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
-
-
 class CFAR(base.CFAR[Array]):
     """Cell-averaging CFAR."""
 
@@ -56,7 +40,9 @@ class CFAR(base.CFAR[Array]):
         Float[Array, "batch range doppler"],
         Float[Array, "batch range doppler"],
     ]:
-        signal = _integrate(signal_cube)
+        # Non-coherent integration over the channel axis, offset by 1 so
+        # that an empty cell has unit power instead of dividing by zero.
+        signal = jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         _, s_r, _ = signal.shape
 
         noise_r = jax.vmap(self._noise)(signal)
@@ -87,11 +73,13 @@ class CFARCASO(base.CFARCASO[Array]):
     ) -> tuple[Bool[Array, "..."], Float[Array, "..."]]:
         """Run 1D CFAR CASO along `axis` of an arbitrarily batched array.
 
-        The training cells are a contiguous box on each side of the cell under
-        test, so the leading and trailing one-sided means are accumulated
-        directly from shifted slices rather than correlated against a mostly
-        zero kernel. `train` is a static Python int, so the sum unrolls at
-        trace time.
+        Implementation notes:
+
+        - The training cells are a contiguous box on each side of the cell
+            under test, so the leading and trailing one-sided means are
+            accumulated directly from shifted slices, rather than correlated
+            against a mostly zero kernel.
+        - `train` is a static Python int, so the sum unrolls at trace time.
 
         Args:
             signal: signal, already padded by `pad` on both ends of `axis`.
@@ -124,7 +112,9 @@ class CFARCASO(base.CFARCASO[Array]):
         Float[Array, "batch range doppler"],
         Float[Array, "batch range doppler"],
     ]:
-        signal = _integrate(signal_cube)
+        # Non-coherent integration over the channel axis, offset by 1 so
+        # that an empty cell has unit power instead of dividing by zero.
+        signal = jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         _, s_r, _ = signal.shape
 
         near, far = self.discard_r[0], self.discard_r[1]

--- a/src/xwr/rsp/jax/spectrum.py
+++ b/src/xwr/rsp/jax/spectrum.py
@@ -20,7 +20,7 @@ jax.tree_util.register_dataclass(
 from a `jax.jit`-ed function."""
 
 
-class CFAR(base.CFAR[Array]):
+class CACFAR(base.CACFAR[Array]):
     """Cell-averaging CFAR."""
 
     def _noise(
@@ -37,16 +37,13 @@ class CFAR(base.CFAR[Array]):
     def _cfar(
         self, signal_cube: Float[Array, "batch doppler channel range"]
     ) -> base.Detection[Array]:
-        # Non-coherent integration over the channel axis, offset by 1 so
-        # that an empty cell has unit power instead of dividing by zero.
+        # Offset by 1 to prevent division by zero for SNR calculations.
         signal = jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         _, s_r, _ = signal.shape
 
         noise_r = jax.vmap(self._noise)(signal)
 
         near, far = self.discard_r[0], self.discard_r[1]
-        # 1 outside the discarded band, so the reported SNR there is the raw
-        # signal rather than a division by zero.
         noise = jnp.ones_like(signal).at[:, near : s_r - far].set(
             noise_r[:, near : s_r - far])
 
@@ -57,7 +54,7 @@ class CFAR(base.CFAR[Array]):
         return base.Detection(obj_mask, signal, snr)
 
 
-class CFARCASO(base.CFARCASO[Array]):
+class CASOCFAR(base.CASOCFAR[Array]):
     """Cell-averaging Smallest of CFAR."""
 
     @staticmethod
@@ -105,8 +102,7 @@ class CFARCASO(base.CFARCASO[Array]):
     def _cfar(
         self, signal_cube: Float[Array, "batch doppler channel range"]
     ) -> base.Detection[Array]:
-        # Non-coherent integration over the channel axis, offset by 1 so
-        # that an empty cell has unit power instead of dividing by zero.
+        # Offset by 1 to prevent division by zero for SNR calculations.
         signal = jnp.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         _, s_r, _ = signal.shape
 
@@ -124,12 +120,9 @@ class CFARCASO(base.CFARCASO[Array]):
             signal, ((0, 0), (0, 0), (self.pad_d, self.pad_d)), mode="wrap"
         )
 
-        # detection
         detect_r, noise_r = self._caso(
             sig_pad_r, 1, self.train_r, self.pad_r, self.snr_r)
         detect_r = jnp.pad(detect_r, ((0, 0), (near, far), (0, 0)))
-        # 1 outside the discarded band, so the reported SNR there is the raw
-        # signal rather than a division by zero.
         noise = jnp.pad(
             noise_r, ((0, 0), (near, far), (0, 0)), constant_values=1)
         detect_d, _ = self._caso(


### PR DESCRIPTION
Jax: update from original implementation; follow the CACFAR/CASOCFAR base class
- `PointCloud` processes a batch of cubes, with the angle spectrum argmax reduced to a single reshape + argmax rather than a nested vmap.
- `CFAR` reports a linear-power SNR against a ring-averaged noise floor instead of a z-score.
- `CFARCASO` accumulates its one-sided means from shifted slices, reducing vmap used and improving runtime.
- All batched processes