### PR TITLE
numpy point cloud and CFAR backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "pyserial >= 3.5",
     "types-pyserial >= 3.5",
     "jaxtyping >= 0.3.2",
-    "pyFFTW >= 0.15.0"
+    "pyFFTW >= 0.15.0",
+    "scipy >= 1.10"
 ]
 
 [project.optional-dependencies]

--- a/src/xwr/rsp/numpy/__init__.py
+++ b/src/xwr/rsp/numpy/__init__.py
@@ -1,5 +1,12 @@
 """Radar Signal Processing in Numpy.
 
+!!! info
+
+    In addition to mirroring the functionality of
+    [`xwr.rsp.jax`][xwr.rsp.jax] and [`xwr.rsp.torch`][xwr.rsp.torch], this
+    module also provides a range of point cloud processing algorithms,
+    mirroring both.
+
 !!! tip
 
     We use [pyfftw](https://pyfftw.readthedocs.io/en/latest/index.html)
@@ -25,6 +32,7 @@
 from jaxtyping import install_import_hook
 
 with install_import_hook("xwr.rsp.numpy", "beartype.beartype"):
+    from .aoa import PointCloud  # noqa: I001
     from .rsp import (
         AWR1843AOP,
         AWR2944EVM,
@@ -33,6 +41,7 @@ with install_import_hook("xwr.rsp.numpy", "beartype.beartype"):
         AWR1843Boost,
         RSPNumpy,
     )
+    from .spectrum import CFAR, CFARCASO
 
 
 __all__ = [
@@ -42,4 +51,7 @@ __all__ = [
     "AWR2944EVM",
     "AWRL6844EVM",
     "RSPNumpy",
+    "CFAR",
+    "CFARCASO",
+    "PointCloud",
 ]

--- a/src/xwr/rsp/numpy/__init__.py
+++ b/src/xwr/rsp/numpy/__init__.py
@@ -41,7 +41,7 @@ with install_import_hook("xwr.rsp.numpy", "beartype.beartype"):
         AWR1843Boost,
         RSPNumpy,
     )
-    from .spectrum import CFAR, CFARCASO
+    from .spectrum import CACFAR, CASOCFAR
 
 
 __all__ = [
@@ -51,7 +51,7 @@ __all__ = [
     "AWR2944EVM",
     "AWRL6844EVM",
     "RSPNumpy",
-    "CFAR",
-    "CFARCASO",
+    "CACFAR",
+    "CASOCFAR",
     "PointCloud",
 ]

--- a/src/xwr/rsp/numpy/__init__.py
+++ b/src/xwr/rsp/numpy/__init__.py
@@ -32,7 +32,7 @@
 from jaxtyping import install_import_hook
 
 with install_import_hook("xwr.rsp.numpy", "beartype.beartype"):
-    from .aoa import PointCloud  # noqa: I001
+    from .aoa import PointCloud
     from .rsp import (
         AWR1843AOP,
         AWR2944EVM,

--- a/src/xwr/rsp/numpy/aoa.py
+++ b/src/xwr/rsp/numpy/aoa.py
@@ -1,18 +1,13 @@
 """Angle of Arrival Estimation and Point Cloud Module using Numpy."""
 
 import numpy as np
-from jaxtyping import Bool, Float, Float32, Int
+from jaxtyping import Bool, Float32, Int
 
 from xwr.rsp import aoa as base
 
 
 class PointCloud(base.PointCloud[np.ndarray]):
     """Get radar point cloud from post FFT cube."""
-
-    def _asarray(
-        self, x: Float[np.ndarray, "..."], like: Float32[np.ndarray, "..."]
-    ) -> Float[np.ndarray, "..."]:
-        return x
 
     def aoa(
         self, cube: Float32[np.ndarray, "batch range doppler el az"]
@@ -26,8 +21,8 @@ class PointCloud(base.PointCloud[np.ndarray]):
         cube: Float32[np.ndarray, "batch doppler el az range"],
         mask: Bool[np.ndarray, "batch range doppler"],
     ) -> base.DensePoints[np.ndarray]:
-        el_angles = self._asarray(self._angle_table(cube.shape[2]), cube)
-        az_angles = self._asarray(self._angle_table(cube.shape[3]), cube)
+        el_angles = self._angle_table(cube.shape[2])
+        az_angles = self._angle_table(cube.shape[3])
 
         _, r_size, d_size = mask.shape
         range_v = np.arange(r_size) * self.range_res

--- a/src/xwr/rsp/numpy/aoa.py
+++ b/src/xwr/rsp/numpy/aoa.py
@@ -9,8 +9,9 @@ from xwr.rsp import aoa as base
 class PointCloud(base.PointCloud[np.ndarray]):
     """Get radar point cloud from post FFT cube."""
 
-    @staticmethod
-    def _asarray(x: Float[np.ndarray, "..."]) -> Float[np.ndarray, "..."]:
+    def _asarray(
+        self, x: Float[np.ndarray, "..."], like: Float32[np.ndarray, "..."]
+    ) -> Float[np.ndarray, "..."]:
         return x
 
     @staticmethod
@@ -29,14 +30,17 @@ class PointCloud(base.PointCloud[np.ndarray]):
         Bool[np.ndarray, "batch range doppler"],
         Float32[np.ndarray, "batch range doppler 4"],
     ]:
+        el_angles = self._asarray(self.angle_table(cube.shape[2]), cube)
+        az_angles = self._asarray(self.angle_table(cube.shape[3]), cube)
+
         _, r_size, d_size = mask.shape
         range_v = np.arange(r_size) * self.range_res
         doppler_v = (np.arange(d_size) - d_size // 2) * self.doppler_res
         r_grid, d_grid = np.meshgrid(range_v, doppler_v, indexing="ij")
 
         angle_idx = self.aoa(cube.transpose(0, 4, 1, 2, 3))
-        ang_e = self.el_angles[angle_idx[..., 0]]
-        ang_a = self.az_angles[angle_idx[..., 1]]
+        ang_e = el_angles[angle_idx[..., 0]]
+        ang_a = az_angles[angle_idx[..., 1]]
         mask_e = np.logical_and(ang_e < self.el_fov, ang_e > -self.el_fov)
         mask_a = np.logical_and(ang_a < self.az_fov, ang_a > -self.az_fov)
         mask_ang = np.logical_and(mask_a, mask_e)

--- a/src/xwr/rsp/numpy/aoa.py
+++ b/src/xwr/rsp/numpy/aoa.py
@@ -29,8 +29,8 @@ class PointCloud(base.PointCloud[np.ndarray]):
         Bool[np.ndarray, "batch range doppler"],
         Float32[np.ndarray, "batch range doppler 4"],
     ]:
-        el_angles = self._asarray(self.angle_table(cube.shape[2]), cube)
-        az_angles = self._asarray(self.angle_table(cube.shape[3]), cube)
+        el_angles = self._asarray(self._angle_table(cube.shape[2]), cube)
+        az_angles = self._asarray(self._angle_table(cube.shape[3]), cube)
 
         _, r_size, d_size = mask.shape
         range_v = np.arange(r_size) * self.range_res

--- a/src/xwr/rsp/numpy/aoa.py
+++ b/src/xwr/rsp/numpy/aoa.py
@@ -1,0 +1,52 @@
+"""Angle of Arrival Estimation and Point Cloud Module using Numpy."""
+
+import numpy as np
+from jaxtyping import Bool, Float, Float32, Int
+
+from xwr.rsp import aoa as base
+
+
+class PointCloud(base.PointCloud[np.ndarray]):
+    """Get radar point cloud from post FFT cube."""
+
+    @staticmethod
+    def _asarray(x: Float[np.ndarray, "..."]) -> Float[np.ndarray, "..."]:
+        return x
+
+    @staticmethod
+    def _argmax_aoa(ang_sptr: Float32[np.ndarray, "... el az"]) -> Int[
+        np.ndarray, "... 2"
+    ]:
+        el, az = ang_sptr.shape[-2:]
+        idx = np.argmax(ang_sptr.reshape(*ang_sptr.shape[:-2], el * az), -1)
+        return np.stack((idx // az, idx % az), axis=-1)
+
+    def _point_cloud(
+        self,
+        cube: Float32[np.ndarray, "batch doppler el az range"],
+        mask: Bool[np.ndarray, "batch range doppler"],
+    ) -> tuple[
+        Bool[np.ndarray, "batch range doppler"],
+        Float32[np.ndarray, "batch range doppler 4"],
+    ]:
+        _, r_size, d_size = mask.shape
+        range_v = np.arange(r_size) * self.range_res
+        doppler_v = (np.arange(d_size) - d_size // 2) * self.doppler_res
+        r_grid, d_grid = np.meshgrid(range_v, doppler_v, indexing="ij")
+
+        angle_idx = self.aoa(cube.transpose(0, 4, 1, 2, 3))
+        ang_e = self.el_angles[angle_idx[..., 0]]
+        ang_a = self.az_angles[angle_idx[..., 1]]
+        mask_e = np.logical_and(ang_e < self.el_fov, ang_e > -self.el_fov)
+        mask_a = np.logical_and(ang_a < self.az_fov, ang_a > -self.az_fov)
+        mask_ang = np.logical_and(mask_a, mask_e)
+
+        x = r_grid * np.cos(-ang_a) * np.cos(ang_e)
+        y = r_grid * np.sin(-ang_a) * np.cos(ang_e)
+        z = r_grid * np.sin(ang_e)
+        v = np.broadcast_to(d_grid, x.shape)
+
+        pc_mask = np.logical_and(mask, mask_ang)
+        pc = np.stack((x, y, z, v), axis=-1).astype(np.float32)
+
+        return pc_mask, pc

--- a/src/xwr/rsp/numpy/aoa.py
+++ b/src/xwr/rsp/numpy/aoa.py
@@ -14,15 +14,14 @@ class PointCloud(base.PointCloud[np.ndarray]):
     ) -> Float[np.ndarray, "..."]:
         return x
 
-    @staticmethod
-    def _argmax_aoa(ang_sptr: Float32[np.ndarray, "... el az"]) -> Int[
-        np.ndarray, "... 2"
-    ]:
-        el, az = ang_sptr.shape[-2:]
-        idx = np.argmax(ang_sptr.reshape(*ang_sptr.shape[:-2], el * az), -1)
+    def aoa(
+        self, cube: Float32[np.ndarray, "batch range doppler el az"]
+    ) -> Int[np.ndarray, "batch range doppler 2"]:
+        el, az = cube.shape[-2:]
+        idx = np.argmax(cube.reshape(*cube.shape[:-2], el * az), -1)
         return np.stack((idx // az, idx % az), axis=-1)
 
-    def _point_cloud(
+    def __call__(
         self,
         cube: Float32[np.ndarray, "batch doppler el az range"],
         mask: Bool[np.ndarray, "batch range doppler"],

--- a/src/xwr/rsp/numpy/aoa.py
+++ b/src/xwr/rsp/numpy/aoa.py
@@ -25,10 +25,7 @@ class PointCloud(base.PointCloud[np.ndarray]):
         self,
         cube: Float32[np.ndarray, "batch doppler el az range"],
         mask: Bool[np.ndarray, "batch range doppler"],
-    ) -> tuple[
-        Bool[np.ndarray, "batch range doppler"],
-        Float32[np.ndarray, "batch range doppler 4"],
-    ]:
+    ) -> base.DensePoints[np.ndarray]:
         el_angles = self._asarray(self._angle_table(cube.shape[2]), cube)
         az_angles = self._asarray(self._angle_table(cube.shape[3]), cube)
 
@@ -52,4 +49,4 @@ class PointCloud(base.PointCloud[np.ndarray]):
         pc_mask = np.logical_and(mask, mask_ang)
         pc = np.stack((x, y, z, v), axis=-1).astype(np.float32)
 
-        return pc_mask, pc
+        return base.DensePoints(pc_mask, pc)

--- a/src/xwr/rsp/numpy/spectrum.py
+++ b/src/xwr/rsp/numpy/spectrum.py
@@ -39,11 +39,7 @@ class CFAR(base.CFAR[np.ndarray]):
 
     def _cfar(
         self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
-    ) -> tuple[
-        Bool[np.ndarray, "batch range doppler"],
-        Float[np.ndarray, "batch range doppler"],
-        Float[np.ndarray, "batch range doppler"],
-    ]:
+    ) -> base.Detection[np.ndarray]:
         signal = _integrate(signal_cube)
         _, s_r, _ = signal.shape
 
@@ -60,7 +56,7 @@ class CFAR(base.CFAR[np.ndarray]):
         obj_mask[:, near : s_r - far] = (
             snr[:, near : s_r - far] > self.snr_thresh)
 
-        return obj_mask, signal, snr
+        return base.Detection(obj_mask, signal, snr)
 
 
 class CFARCASO(base.CFARCASO[np.ndarray]):
@@ -107,11 +103,7 @@ class CFARCASO(base.CFARCASO[np.ndarray]):
 
     def _cfar(
         self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
-    ) -> tuple[
-        Bool[np.ndarray, "batch range doppler"],
-        Float[np.ndarray, "batch range doppler"],
-        Float[np.ndarray, "batch range doppler"],
-    ]:
+    ) -> base.Detection[np.ndarray]:
         signal = _integrate(signal_cube)
         batch, s_r, s_d = signal.shape
 
@@ -154,4 +146,4 @@ class CFARCASO(base.CFARCASO[np.ndarray]):
         snr = signal / noise
         obj_mask = np.logical_and(detect, detect_d)
 
-        return obj_mask, signal, snr
+        return base.Detection(obj_mask, signal, snr)

--- a/src/xwr/rsp/numpy/spectrum.py
+++ b/src/xwr/rsp/numpy/spectrum.py
@@ -10,10 +10,6 @@ from xwr.rsp import spectrum as base
 class CFAR(base.CFAR[np.ndarray]):
     """Cell-averaging CFAR."""
 
-    @staticmethod
-    def _asarray(x: Float[np.ndarray, "..."]) -> Float[np.ndarray, "..."]:
-        return x
-
     def _noise(
         self, signal: Float[np.ndarray, "range doppler"]
     ) -> Float[np.ndarray, "range doppler"]:

--- a/src/xwr/rsp/numpy/spectrum.py
+++ b/src/xwr/rsp/numpy/spectrum.py
@@ -7,22 +7,6 @@ from scipy.signal import convolve2d, correlate
 from xwr.rsp import spectrum as base
 
 
-def _integrate(
-    signal_cube: Float[np.ndarray, "batch doppler channel range"]
-) -> Float[np.ndarray, "batch range doppler"]:
-    """Combine the channel axis non-coherently into a range-doppler image.
-
-    Args:
-        signal_cube: batch of post range doppler FFT radar cubes in amplitude,
-            flattened to a single channel axis.
-
-    Returns:
-        Integrated power, offset by 1 so that an empty cell has unit power
-            instead of dividing by zero downstream.
-    """
-    return np.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
-
-
 class CFAR(base.CFAR[np.ndarray]):
     """Cell-averaging CFAR."""
 
@@ -40,7 +24,9 @@ class CFAR(base.CFAR[np.ndarray]):
     def _cfar(
         self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
     ) -> base.Detection[np.ndarray]:
-        signal = _integrate(signal_cube)
+        # Non-coherent integration over the channel axis, offset by 1 so
+        # that an empty cell has unit power instead of dividing by zero.
+        signal = np.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         _, s_r, _ = signal.shape
 
         noise_r = np.stack([self._noise(s) for s in signal])
@@ -104,7 +90,9 @@ class CFARCASO(base.CFARCASO[np.ndarray]):
     def _cfar(
         self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
     ) -> base.Detection[np.ndarray]:
-        signal = _integrate(signal_cube)
+        # Non-coherent integration over the channel axis, offset by 1 so
+        # that an empty cell has unit power instead of dividing by zero.
+        signal = np.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         batch, s_r, s_d = signal.shape
 
         near, far = self.discard_r[0], self.discard_r[1]

--- a/src/xwr/rsp/numpy/spectrum.py
+++ b/src/xwr/rsp/numpy/spectrum.py
@@ -7,7 +7,7 @@ from scipy.signal import convolve2d, correlate
 from xwr.rsp import spectrum as base
 
 
-class CFAR(base.CFAR[np.ndarray]):
+class CACFAR(base.CACFAR[np.ndarray]):
     """Cell-averaging CFAR."""
 
     def _noise(
@@ -20,16 +20,13 @@ class CFAR(base.CFAR[np.ndarray]):
     def _cfar(
         self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
     ) -> base.Detection[np.ndarray]:
-        # Non-coherent integration over the channel axis, offset by 1 so
-        # that an empty cell has unit power instead of dividing by zero.
+        # Offset by 1 to prevent division by zero for SNR calculations.
         signal = np.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         _, s_r, _ = signal.shape
 
         noise_r = np.stack([self._noise(s) for s in signal])
 
         near, far = self.discard_r[0], self.discard_r[1]
-        # 1 outside the discarded band, so the reported SNR there is the raw
-        # signal rather than a division by zero.
         noise = np.ones_like(signal)
         noise[:, near : s_r - far] = noise_r[:, near : s_r - far]
 
@@ -41,7 +38,7 @@ class CFAR(base.CFAR[np.ndarray]):
         return base.Detection(obj_mask, signal, snr)
 
 
-class CFARCASO(base.CFARCASO[np.ndarray]):
+class CASOCFAR(base.CASOCFAR[np.ndarray]):
     """Cell-averaging Smallest of CFAR."""
 
     def __init__(
@@ -53,8 +50,6 @@ class CFARCASO(base.CFARCASO[np.ndarray]):
     ) -> None:
         super().__init__(guard, train, snr_thresh, discard_range)
 
-        # Unlike the jax backend, which accumulates the one-sided means from
-        # shifted slices, scipy correlates against an explicit kernel.
         def make_caso_kernels(n_train, pad):
             ker = np.zeros((2 * pad + 1), dtype=np.float32)
             ker_a, ker_b = ker.copy(), ker.copy()
@@ -86,8 +81,7 @@ class CFARCASO(base.CFARCASO[np.ndarray]):
     def _cfar(
         self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
     ) -> base.Detection[np.ndarray]:
-        # Non-coherent integration over the channel axis, offset by 1 so
-        # that an empty cell has unit power instead of dividing by zero.
+        # Offset by 1 to prevent division by zero for SNR calculations.
         signal = np.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
         batch, s_r, s_d = signal.shape
 
@@ -105,8 +99,6 @@ class CFARCASO(base.CFARCASO[np.ndarray]):
             signal, ((0, 0), (0, 0), (self.pad_d, self.pad_d)), mode="wrap"
         )
 
-        # detection: loop over (batch, doppler) rows for the range axis, and
-        # over (batch, range) rows for the doppler axis.
         detect_r = np.zeros((batch, s_r - near - far, s_d), dtype=bool)
         noise_r = np.zeros((batch, s_r - near - far, s_d), dtype=np.float32)
         for b in range(batch):

--- a/src/xwr/rsp/numpy/spectrum.py
+++ b/src/xwr/rsp/numpy/spectrum.py
@@ -1,0 +1,156 @@
+"""Calibrated Spectrum Processing."""
+
+import numpy as np
+from jaxtyping import Bool, Float
+from scipy.signal import convolve2d, correlate
+
+from xwr.rsp import spectrum as base
+
+
+def _integrate(
+    signal_cube: Float[np.ndarray, "batch doppler tx rx range"]
+) -> Float[np.ndarray, "batch range doppler"]:
+    """Combine the virtual array non-coherently into a range-doppler image.
+
+    Args:
+        signal_cube: batch of post range doppler FFT radar cubes in amplitude.
+
+    Returns:
+        Integrated power, offset by 1 so that an empty cell has unit power
+            instead of dividing by zero downstream.
+    """
+    return np.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
+
+
+class CFAR(base.CFAR[np.ndarray]):
+    """Cell-averaging CFAR."""
+
+    @staticmethod
+    def _asarray(x: Float[np.ndarray, "..."]) -> Float[np.ndarray, "..."]:
+        return x
+
+    def _noise(
+        self, signal: Float[np.ndarray, "range doppler"]
+    ) -> Float[np.ndarray, "range doppler"]:
+        """Get the ring-averaged noise floor for a range-doppler image."""
+        valid = convolve2d(np.ones_like(signal), self.mask, mode="same")
+        return convolve2d(signal, self.mask, mode="same") / valid
+
+    def _cfar(
+        self, signal_cube: Float[np.ndarray, "batch doppler tx rx range"]
+    ) -> tuple[
+        Bool[np.ndarray, "batch range doppler"],
+        Float[np.ndarray, "batch range doppler"],
+        Float[np.ndarray, "batch range doppler"],
+    ]:
+        signal = _integrate(signal_cube)
+        _, s_r, _ = signal.shape
+
+        noise_r = np.stack([self._noise(s) for s in signal])
+
+        near, far = self.discard_r[0], self.discard_r[1]
+        # 1 outside the discarded band, so the reported SNR there is the raw
+        # signal rather than a division by zero.
+        noise = np.ones_like(signal)
+        noise[:, near : s_r - far] = noise_r[:, near : s_r - far]
+
+        snr = signal / noise
+        obj_mask = np.zeros(signal.shape, dtype=bool)
+        obj_mask[:, near : s_r - far] = (
+            snr[:, near : s_r - far] > self.snr_thresh)
+
+        return obj_mask, signal, snr
+
+
+class CFARCASO(base.CFARCASO[np.ndarray]):
+    """Cell-averaging Smallest of CFAR."""
+
+    def __init__(
+        self,
+        guard: tuple[int, int] = (8, 0),
+        train: tuple[int, int] = (8, 4),
+        snr_thresh: tuple[float, float] = (5.0, 3.0),
+        discard_range: tuple[int, int] = (10, 20),
+    ) -> None:
+        super().__init__(guard, train, snr_thresh, discard_range)
+
+        # Unlike the jax backend, which accumulates the one-sided means from
+        # shifted slices, scipy correlates against an explicit kernel.
+        def make_caso_kernels(n_train, pad):
+            ker = np.zeros((2 * pad + 1), dtype=np.float32)
+            ker_a, ker_b = ker.copy(), ker.copy()
+            ker_a[:n_train], ker_b[-n_train:] = 1, 1
+            ker_a /= ker_a.sum()
+            ker_b /= ker_b.sum()
+            return ker_a, ker_b
+
+        self.r_ker_a, self.r_ker_b = make_caso_kernels(
+            self.train_r, self.pad_r)
+        self.d_ker_a, self.d_ker_b = make_caso_kernels(
+            self.train_d, self.pad_d)
+
+    @staticmethod
+    def _caso(
+        signal: Float[np.ndarray, "n"],
+        ker_a: Float[np.ndarray, "w"],
+        ker_b: Float[np.ndarray, "w"],
+        snr: float,
+        pad: int,
+    ) -> tuple[Bool[np.ndarray, "m"], Float[np.ndarray, "m"]]:
+        """Run 1D CFAR CASO, returning a detection mask and noise level."""
+        cor_a = correlate(signal, ker_a, mode="valid")
+        cor_b = correlate(signal, ker_b, mode="valid")
+        noise = np.minimum(cor_a, cor_b)
+        detect = signal[pad:-pad] > snr * noise
+        return detect, noise
+
+    def _cfar(
+        self, signal_cube: Float[np.ndarray, "batch doppler tx rx range"]
+    ) -> tuple[
+        Bool[np.ndarray, "batch range doppler"],
+        Float[np.ndarray, "batch range doppler"],
+        Float[np.ndarray, "batch range doppler"],
+    ]:
+        signal = _integrate(signal_cube)
+        batch, s_r, s_d = signal.shape
+
+        near, far = self.discard_r[0], self.discard_r[1]
+        sig_discard = signal[:, near : s_r - far]
+        sig_pad_r = np.concatenate(
+            (
+                sig_discard[:, : self.pad_r],
+                sig_discard,
+                sig_discard[:, -self.pad_r :],
+            ),
+            axis=1,
+        )
+        sig_pad_d = np.pad(
+            signal, ((0, 0), (0, 0), (self.pad_d, self.pad_d)), mode="wrap"
+        )
+
+        # detection: loop over (batch, doppler) rows for the range axis, and
+        # over (batch, range) rows for the doppler axis.
+        detect_r = np.zeros((batch, s_r - near - far, s_d), dtype=bool)
+        noise_r = np.zeros((batch, s_r - near - far, s_d), dtype=np.float32)
+        for b in range(batch):
+            for d in range(s_d):
+                detect_r[b, :, d], noise_r[b, :, d] = self._caso(
+                    sig_pad_r[b, :, d], self.r_ker_a, self.r_ker_b,
+                    self.snr_r, self.pad_r)
+
+        detect = np.zeros(signal.shape, dtype=bool)
+        detect[:, near : s_r - far] = detect_r
+        noise = np.ones(signal.shape, dtype=np.float32)
+        noise[:, near : s_r - far] = noise_r
+
+        detect_d = np.zeros((batch, s_r, s_d), dtype=bool)
+        for b in range(batch):
+            for r in range(s_r):
+                detect_d[b, r, :], _ = self._caso(
+                    sig_pad_d[b, r, :], self.d_ker_a, self.d_ker_b,
+                    self.snr_d, self.pad_d)
+
+        snr = signal / noise
+        obj_mask = np.logical_and(detect, detect_d)
+
+        return obj_mask, signal, snr

--- a/src/xwr/rsp/numpy/spectrum.py
+++ b/src/xwr/rsp/numpy/spectrum.py
@@ -8,18 +8,19 @@ from xwr.rsp import spectrum as base
 
 
 def _integrate(
-    signal_cube: Float[np.ndarray, "batch doppler tx rx range"]
+    signal_cube: Float[np.ndarray, "batch doppler channel range"]
 ) -> Float[np.ndarray, "batch range doppler"]:
-    """Combine the virtual array non-coherently into a range-doppler image.
+    """Combine the channel axis non-coherently into a range-doppler image.
 
     Args:
-        signal_cube: batch of post range doppler FFT radar cubes in amplitude.
+        signal_cube: batch of post range doppler FFT radar cubes in amplitude,
+            flattened to a single channel axis.
 
     Returns:
         Integrated power, offset by 1 so that an empty cell has unit power
             instead of dividing by zero downstream.
     """
-    return np.sum(signal_cube**2, axis=(2, 3)).transpose(0, 2, 1) + 1
+    return np.sum(signal_cube**2, axis=2).transpose(0, 2, 1) + 1
 
 
 class CFAR(base.CFAR[np.ndarray]):
@@ -37,7 +38,7 @@ class CFAR(base.CFAR[np.ndarray]):
         return convolve2d(signal, self.mask, mode="same") / valid
 
     def _cfar(
-        self, signal_cube: Float[np.ndarray, "batch doppler tx rx range"]
+        self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
     ) -> tuple[
         Bool[np.ndarray, "batch range doppler"],
         Float[np.ndarray, "batch range doppler"],
@@ -105,7 +106,7 @@ class CFARCASO(base.CFARCASO[np.ndarray]):
         return detect, noise
 
     def _cfar(
-        self, signal_cube: Float[np.ndarray, "batch doppler tx rx range"]
+        self, signal_cube: Float[np.ndarray, "batch doppler channel range"]
     ) -> tuple[
         Bool[np.ndarray, "batch range doppler"],
         Float[np.ndarray, "batch range doppler"],

--- a/uv.lock
+++ b/uv.lock
@@ -1924,6 +1924,8 @@ dependencies = [
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyfftw" },
     { name = "pyserial" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "types-pyserial" },
 ]
 
@@ -1978,6 +1980,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.0" },
     { name = "ruff", marker = "extra == 'docs'", specifier = ">=0.11.0" },
+    { name = "scipy", specifier = ">=1.10" },
     { name = "torch", marker = "extra == 'nn'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.0" },
     { name = "torchvision", marker = "extra == 'nn'", specifier = ">=0.15.0" },


### PR DESCRIPTION
- Adds `PointCloud`, `CFAR`, and `CFARCASO` to `xwr.rsp.numpy`, following the shared base class implementation.
- Declares `scipy` as a dependency: `xwr.rsp.numpy.spectrum` imports `scipy.signal`, which until now only reached the environment transitively via jax or torch, so `xwr.rsp.numpy` would fail to import on a bare install.